### PR TITLE
fix typo "libary" in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ as well as specifying a special flag when running Prettier:
 # Start the server (if installed globally)
 start-apex-server
 # Or if installed locally
-node /path/to/libary/bin/start-apex-server.js
+node /path/to/library/bin/start-apex-server.js
 
 # In a separate console
 prettier --apex-standalone-parser built-in --write "/path/to/project/**/*.{trigger,cls}"
@@ -175,5 +175,5 @@ prettier --apex-standalone-parser built-in --write "/path/to/project/**/*.{trigg
 # After you are done, stop the server (if installed globally)
 stop-apex-server
 # Or if installed locally
-node /path/to/libary/bin/stop-apex-server.js
+node /path/to/library/bin/stop-apex-server.js
 ```


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fix typo in Readme

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [X] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
