### PR TITLE
Adding * to all lines of "block" comments

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -24,13 +24,21 @@ function printApexDocComment(comment) {
   return concat([
     join(
       hardline,
-      lines.map(
-        (commentLine, index) =>
+      lines.map((commentLine, index) => {
+        const line =
           (index > 0 ? " " : "") +
           (index < lines.length - 1
             ? commentLine.trim()
-            : commentLine.trimLeft()),
-      ),
+            : commentLine.trimLeft());
+        if (
+          index > 0 &&
+          index < lines.length - 1 &&
+          !line.trim().startsWith("*")
+        ) {
+          return ` *${line}`;
+        }
+        return line;
+      }),
     ),
   ]);
 }

--- a/src/util.js
+++ b/src/util.js
@@ -20,9 +20,8 @@ function isApexDocComment(comment) {
   const lines = comment.value.split("\n");
   return (
     lines.length > 1 &&
-    lines
-      .slice(1, lines.length - 1)
-      .every(commentLine => commentLine.trim()[0] === "*")
+    lines[0].trim().startsWith("/**") &&
+    lines[lines.length - 1].trim().startsWith("*/")
   );
 }
 

--- a/tests/comments_before_declaration/CommentsBeforeEnumDeclaration.cls
+++ b/tests/comments_before_declaration/CommentsBeforeEnumDeclaration.cls
@@ -2,5 +2,6 @@
 
 /**
 * First ApexDoc
+  Description
 */
 enum Season {WINTER, SPRING, SUMMER, FALL}

--- a/tests/comments_before_declaration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_before_declaration/__snapshots__/jsfmt.spec.js.snap
@@ -30,6 +30,7 @@ exports[`Format apex: CommentsBeforeEnumDeclaration.cls: CommentsBeforeEnumDecla
 
 /**
 * First ApexDoc
+  Description
 */
 enum Season {WINTER, SPRING, SUMMER, FALL}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -37,6 +38,7 @@ enum Season {WINTER, SPRING, SUMMER, FALL}
 
 /**
  * First ApexDoc
+ * Description
  */
 enum Season {
   WINTER,


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Potential Fix for #150.  Still WIP (didn't want to spend too much time if #150 isn't a valid request).

Couple other thoughts:

1. I modified the definition of an `IsApexDoc` because this seemed like the easiest way to get there.  It might make sense to instead differentiate between ApexDoc & other Block comment and handle those printers separate?  Although after applying this change, any "non ApexDoc Block comment" would become and ApexDoc by the current definitions... so maybe not.
2. Need to break out dedicated tests.  I just highjacked an existing tests for now.
3. Would like to do more functional testing but I struggled to get this to run locally.  I tried to `npm link prettier-plugin-apex`, but then it just caused prettier to break with `Unexpected type string`.



<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works. (sorta)
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).


