### PR TITLE
Fixes weird new List<Object>(size) syntax with new Object[size]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Always break up TYPEOF SOQL queries ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/244)).
 
-- Fixes weird `new List<Object>(0)` constructor with the more usual `new Object[0]` syntax when possible. Also adds new tests that cover edge cases. 
+- Fixes weird `new List<Object>(0)` constructor with the more usual `new Object[0]` syntax when possible. Also adds new tests that cover edge cases. (credit to @brianmfear)
 
 # 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Always break up TYPEOF SOQL queries ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/244)).
 
+- Fixes weird `new List<Object>(0)` constructor with the more usual `new Object[0]` syntax when possible. Also adds new tests that cover edge cases. 
+
 # 1.6.0
 
 - Handle new jorje structure for types in enhanced for loops.

--- a/src/printer.js
+++ b/src/printer.js
@@ -1284,9 +1284,9 @@ function handleNewListInit(path, print) {
 
   const expressionDoc = path.call(print, "expr", "value");
   const parts = [];
-  const typePart = path.map(print, "types");
+  const node = path.getValue();
   const hasLiteralNumberInitializer =
-    (typePart.group || (typePart.length && typePart[0].parts.length < 4)) &&
+    (typePart.group || (node.types.length && node.types[0].parts.length < 4)) &&
     !Number.isNaN(parseInt(expressionDoc, 10));
 
   // Type

--- a/src/printer.js
+++ b/src/printer.js
@@ -1286,8 +1286,7 @@ function handleNewListInit(path, print) {
   const parts = [];
   const node = path.getValue();
   const hasLiteralNumberInitializer =
-    (typePart.group || (node.types.length && node.types[0].parts.length < 4)) &&
-    !Number.isNaN(parseInt(expressionDoc, 10));
+    node.expr && node.expr.type && node.expr.type['$'] === 'INTEGER';
 
   // Type
   if (!hasLiteralNumberInitializer) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -1293,7 +1293,7 @@ function handleNewListInit(path, print) {
   if (!hasLiteralNumberInitializer) {
     parts.push("List<");
   }
-  parts.push(join(".", typePart));
+  parts.push(join(".", node.types));
   if (!hasLiteralNumberInitializer) {
     parts.push(">");
   }

--- a/src/printer.js
+++ b/src/printer.js
@@ -1271,7 +1271,7 @@ function handleNewSetLiteral(path, print) {
 }
 
 function handleNewListInit(path, print) {
-  // We can delcare lists in the following ways:
+  // We can declare lists in the following ways:
   // new Object[size];
   // new Object[] { value, ... };
   // new List<Object>(); // Provides AST consistency.

--- a/src/printer.js
+++ b/src/printer.js
@@ -1271,32 +1271,36 @@ function handleNewSetLiteral(path, print) {
 }
 
 function handleNewListInit(path, print) {
-  // Technically there are 2 ways to declare new list:
-  // - new String[]{};
-  // - new List<String>{};
-  // We use the 2nd format because it can handle any type of new list, e.g.
-  // This is correct:
-  // List<List<String>> data = new List<List<String>>{};
-  // But this is not:
-  // List<List<String>> data = new List<String>[]{};
+  // We can delcare lists in the following ways:
+  // new Object[size];
+  // new Object[] { value, ... };
+  // new List<Object>(); // Provides AST consistency.
+  // new List<Object>(size);
 
-  // Other quirks:
-  // All of these are correct:
-  // Id[] ids = new Id[]{};
-  // Id[] ids = new Id[1];
-  // Id[] ids = new Id[anotherIds];
-  // But this is not correct:
-  // Id[] ids = new Id[1]{};
+  // We use Object[size] if a literal number is provided.
+  // We use List<Object>(param) otherwise.
+  // This should provide compatibility for all known types without knowing
+  // if the parameter is a variable (copy constructor) or literal size.
+
   const expressionDoc = path.call(print, "expr", "value");
   const parts = [];
+  const typePart = path.map(print, "types");
+  const hasLiteralNumberInitializer =
+    (typePart.group || (typePart.length && typePart[0].parts.length < 4)) &&
+    !Number.isNaN(parseInt(expressionDoc, 10));
+
   // Type
-  parts.push("List<");
-  parts.push(join(".", path.map(print, "types")));
-  parts.push(">");
+  if (!hasLiteralNumberInitializer) {
+    parts.push("List<");
+  }
+  parts.push(join(".", typePart));
+  if (!hasLiteralNumberInitializer) {
+    parts.push(">");
+  }
   // Param
-  parts.push("(");
+  parts.push(hasLiteralNumberInitializer ? "[" : "(");
   _pushIfExist(parts, expressionDoc, [dedent(softline)], [softline]);
-  parts.push(")");
+  parts.push(hasLiteralNumberInitializer ? "]" : ")");
   return groupIndentConcat(parts);
 }
 

--- a/tests/new_object/NewObject.cls
+++ b/tests/new_object/NewObject.cls
@@ -10,7 +10,8 @@ class NewObject {
     String[] d = new String[]{'a', 'b'};
     String[] e = new String[]{'Long string number one', 'Long string number two'};
     String[] f = new String[1];
-    String[] g = new String[f];
+    String[] g = new List<String>(f);
+    String[] h = new String[0];
   }
 
   void newSetTest() {
@@ -61,6 +62,26 @@ class NewObject {
     JWS a = new JWS('payload', 'certDevName');
     JWS b = new JWS('Very long payload but still fit in one line', 'very long cert dev name');
     JWS c = new JWS('Very long payload that is definitely too long so that all the parent groups must break', 'very long cert dev name');
+  }
+
+  void newComplicatedTypesTest() {
+    Map<String, Map<String, String>> a = new Map<String, Map<String, String>> {
+      'a' => new Map<String, String> {
+        'b' => 'c'
+      },
+      'd' => new Map<String, String> {
+        'e' => 'f'
+      }
+    };
+    Map<String, List<String>> b = new Map<String, List<String>> {
+      'a' => new List<String>(5),
+      'b' => new List<String> {'c','d','e'}
+    };
+    Map<List<String>, List<String>> c = new Map<List<String>, List<String>> {
+      new List<String>{'a'} => new List<String>{'b','c'},
+      new List<String>{'d'} => new List<String>{'e','f'}
+    };
+    List<List<String>> d = new List<List<String>>(5);
   }
 }
 

--- a/tests/new_object/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/new_object/__snapshots__/jsfmt.spec.js.snap
@@ -13,7 +13,8 @@ class NewObject {
     String[] d = new String[]{'a', 'b'};
     String[] e = new String[]{'Long string number one', 'Long string number two'};
     String[] f = new String[1];
-    String[] g = new String[f];
+    String[] g = new List<String>(f);
+    String[] h = new String[0];
   }
 
   void newSetTest() {
@@ -65,6 +66,26 @@ class NewObject {
     JWS b = new JWS('Very long payload but still fit in one line', 'very long cert dev name');
     JWS c = new JWS('Very long payload that is definitely too long so that all the parent groups must break', 'very long cert dev name');
   }
+
+  void newComplicatedTypesTest() {
+    Map<String, Map<String, String>> a = new Map<String, Map<String, String>> {
+      'a' => new Map<String, String> {
+        'b' => 'c'
+      },
+      'd' => new Map<String, String> {
+        'e' => 'f'
+      }
+    };
+    Map<String, List<String>> b = new Map<String, List<String>> {
+      'a' => new List<String>(5),
+      'b' => new List<String> {'c','d','e'}
+    };
+    Map<List<String>, List<String>> c = new Map<List<String>, List<String>> {
+      new List<String>{'a'} => new List<String>{'b','c'},
+      new List<String>{'d'} => new List<String>{'e','f'}
+    };
+    List<List<String>> d = new List<List<String>>(5);
+  }
 }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -91,8 +112,9 @@ class NewObject {
       'Long string number one',
       'Long string number two'
     };
-    String[] f = new List<String>(1);
+    String[] f = new String[1];
     String[] g = new List<String>(f);
+    String[] h = new String[0];
   }
 
   void newSetTest() {
@@ -189,6 +211,22 @@ class NewObject {
       'Very long payload that is definitely too long so that all the parent groups must break',
       'very long cert dev name'
     );
+  }
+
+  void newComplicatedTypesTest() {
+    Map<String, Map<String, String>> a = new Map<String, Map<String, String>>{
+      'a' => new Map<String, String>{ 'b' => 'c' },
+      'd' => new Map<String, String>{ 'e' => 'f' }
+    };
+    Map<String, List<String>> b = new Map<String, List<String>>{
+      'a' => new String[5],
+      'b' => new List<String>{ 'c', 'd', 'e' }
+    };
+    Map<List<String>, List<String>> c = new Map<List<String>, List<String>>{
+      new List<String>{ 'a' } => new List<String>{ 'b', 'c' },
+      new List<String>{ 'd' } => new List<String>{ 'e', 'f' }
+    };
+    List<List<String>> d = new List<List<String>>(5);
   }
 }
 

--- a/tests/variable_declaration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/variable_declaration/__snapshots__/jsfmt.spec.js.snap
@@ -45,7 +45,7 @@ public class VariableDeclaration {
     String[] emptyStrings;
     Integer maxNums = 5;
     stringArrays = new List<String>();
-    stringArrays = new List<String>(0);
+    stringArrays = new String[0];
     stringArray = new List<String>(maxNums);
 
     List<String> anotherArray = new List<String>(maxNums);

--- a/tests/variable_declaration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/variable_declaration/__snapshots__/jsfmt.spec.js.snap
@@ -34,7 +34,7 @@ public class VariableDeclaration {
     HttpRequest request = new HttpRequest();
     String[] stringArray = new List<String>{};
     String[] anotherStringArray = new List<String>{ 'a', 'b' };
-    List<String> anotherArray = new List<String>(1);
+    List<String> anotherArray = new String[1];
     String[] emptyStrings;
     String[] otherStrings = new List<String>();
     List<List<String>> listOfList = new List<List<String>>();


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Changes the output for new List<Object>(size); constructors to new Object[size].

This only does so safely; if we cannot determine if the change is safe, we fall back to List<Object>(size);. This is necessary because of the alternative new List<Object>(sourceListOrSet), which I'm not sure we can determine from the AST. No AST changes occur as a result of these changes.

Added a new set of tests to make sure we also handle nested list types, such as Map<String, List<String>> and Map<List<String>, List<String>>.

Fixed the code:

```apex
String[] g = new String[f];
```

In tests/new_object/NewObject.cls (newListTest), which is not valid if f is not an Integer variable; as a side effect, dynamic list sizes use the new List<Object>(size) constructor.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
