### PR TITLE
docs: redirect nohup output

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ By default, the server listens on `http://localhost:2117`.
 This can be customized by specifying the `--host` and `--port` arguments:
 
 ```bash
-start-apex-server --host 127.0.0.1 --port 2117
+start-apex-server --host 127.0.0.1 --port 2118
 ```
 
 ## Continuous Integration
@@ -180,7 +180,7 @@ in the context of CI/CD, for example:
 ```bash
 # Start the language server for improved parsing performance,
 # and put it in the background (*nix only) so that next commands can be run.
-nohup start-apex-server >/dev/null &
+nohup start-apex-server >/dev/null 2>&1 &
 # Wait until the server is up before sending requests
 npx wait-on http://localhost:2117/api/ast/
 # Check that Apex files are formatted according to Prettier Apex style

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ in the context of CI/CD, for example:
 ```bash
 # Start the language server for improved parsing performance,
 # and put it in the background (*nix only) so that next commands can be run.
-nohup start-apex-server &
+nohup start-apex-server >/dev/null &
 # Wait until the server is up before sending requests
 npx wait-on http://localhost:2117/api/ast/
 # Check that Apex files are formatted according to Prettier Apex style

--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ stop-apex-server
 node /path/to/library/bin/stop-apex-server.js
 ```
 
-By default, the server listens on `http://localhost:2118`.
+By default, the server listens on `http://localhost:2117`.
 This can be customized by specifying the `--host` and `--port` arguments:
 
 ```bash
-start-apex-server --host 127.0.0.1 --port 2118
+start-apex-server --host 127.0.0.1 --port 2117
 ```
 
 ## Continuous Integration


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Running with `nohup` creates and writes output to a file on each execution. Might be helpful to suggest redirecting to `/dev/null` to prevent this. 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
