### PR TITLE
fix: explicitly exit the process after starting server

### DIFF
--- a/bin/start-apex-server.ts
+++ b/bin/start-apex-server.ts
@@ -6,6 +6,7 @@ import { start } from "../src/http-server";
 
 async function setup(host: string, port: number) {
   await start(host, port);
+  process.exit();
 }
 
 if (require.main === module) {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I have issues trying to start the server when using the command with `lint-staged` as part of a pre-commit hook using `husky`. I see the server start but the process hangs and never terminates, so I never get a prompt to enter a commit message and finish the commit. 

I found that if I explicitly start the server and then try to make a commit, the pre-commit hook works fine. 

I tried various ways of triggering the start server from the pre-commit hook including with a package manager script like `yarn start-server`, calling the script from this repo directly with the package manager `yarn start-apex-server` and explicitly calling it with node `node /path/to/library/bin/start-apex-server.js` and observed the same behavior with all. 

I used the package [why-is-node-running](https://github.com/mafintosh/why-is-node-running) to determine why the hook wasn't terminating by wrapping the entire `start-apex-server.ts` script. I found that the child processed spawned in `http-server.ts` was preventing the script from terminating, despite the server being up and running. 

I can't tell you exactly why this is happening unfortunately, my best guess is that the node context pre-commit hooks get run from explicitly waits for everything to finish and is slightly different than just running something from the CLI. I found that simply adding this `process.exit()` after the server starts allows the script to terminate successfully from the pre-commit hook and has no effect on how the script behaves when run normally through the CLI. 

I tested this on various version of node including 12, 14 and 16 and observed the same behavior. 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
