### PR TITLE
Annotations starts with an uppercase character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - `start-apex-server` takes optional `-c` flag, which will be passed on to `apex-ast-serializer` as a comma-delimited list of allowed origins that will be added to the CORS headers returned by the parsing server.
 - `start-apex-server` pipes internal logs to console, so that errors can be caught more quickly by users.
 
+## Formatting Changes
+
+- Apex annotations are formated like in the [official documentation](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation.htm). The first character after the `@` is uppercase.
+
 # 1.12.0
 
 ## Formatting Changes

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -674,6 +674,7 @@ function handleAnnotation(path: AstPath, print: printFn): Doc {
   const trailingParts: Doc[] = [];
   const parameterParts = [];
   const parameterDocs: Doc[] = path.map(print, "parameters");
+  let annotationName;
   if (node.comments) {
     // We print the comments manually because this method adds a hardline
     // at the end of the annotation. If we left it to Prettier to print trailing
@@ -694,7 +695,18 @@ function handleAnnotation(path: AstPath, print: printFn): Doc {
     }, "comments");
   }
   parts.push("@");
-  parts.push(path.call(print, "name", "value"));
+
+  // Update the first character of the annotation name to be uppercase
+  annotationName = path.call(print, "name", "value") as string;
+  if (
+    annotationName &&
+    annotationName.length > 0 &&
+    annotationName[0] !== undefined
+  ) {
+    annotationName = annotationName[0].toUpperCase() + annotationName.slice(1);
+  }
+
+  parts.push(annotationName);
   if (parameterDocs.length > 0) {
     parameterParts.push("(");
     parameterParts.push(softline);

--- a/tests/comments/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.ts.snap
@@ -861,7 +861,7 @@ class Comments {
 /**
  * ApexDoc for class
  */
-@isTest(
+@IsTest(
   seeAllData=true // Class annotation inline comment 1
   //isParallel = false // Class annotation inline comment 2
 )
@@ -1670,40 +1670,40 @@ class Comments {
     );
   }
 
-  @isTest // Decorator Trailing Inline Comment 1
+  @IsTest // Decorator Trailing Inline Comment 1
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  /* Decorator Leading Block Comment 1 */ @isTest
+  /* Decorator Leading Block Comment 1 */ @IsTest
   void leadingCommentBeforeAnnotation() {
     System.debug('Hi');
   }
 
-  @isTest // Decorator Trailing Inline Comment 2
+  @IsTest // Decorator Trailing Inline Comment 2
   @AuraEnabled // Decorater Trailing Inline Comment 3
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  @isTest /* Decorator Trailing Block Comment 1 */
+  @IsTest /* Decorator Trailing Block Comment 1 */
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  /* Decorator Leading Block Comment 1 */ @isTest
+  /* Decorator Leading Block Comment 1 */ @IsTest
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  @isTest(
+  @IsTest(
     seeAllData=true // Method annotation inline comment 1
     //isParallel = false // Method annotation inline comment 2
   )
   void methodAnnotationInlineComment() {
   }
 
-  @isTest(
+  @IsTest(
     seeAllData=true /* Method annotation block comment 1 */
     /*isParallel = false // Method annotation block comment 2 */
   )

--- a/tests/run_as/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/run_as/__snapshots__/jsfmt.spec.ts.snap
@@ -34,7 +34,7 @@ class RunAsClass {
 }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@isTest
+@IsTest
 class RunAsClass {
   static testMethod void runAsTest() {
     User userOne = [SELECT Id FROM User LIMIT 1];


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
In apex, annotation start with an uppercase character after the `@`: [doc](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation.htm)
Annotation in Salesforce aren't case sensitive, it's a cosmetic and harmonizing feature.
The goal is to change `@isTest` into `@IsTest`.

It's my first time contributing here, I tried to respect your ways of coding.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
