### PR TITLE
perf: speed up parsing by up to 60%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Fix Windows application not being able to get output from parser when `DEBUG` environment variable is set ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1513)).
-- Parsing up to 60% faster.
+- Improving parsing performance - thanks to @lukecotter for their contribution!
 
 # 2.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix Windows application not being able to get output from parser when `DEBUG` environment variable is set ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1513)).
+- Parsing up to 60% faster.
 
 # 2.1.4
 

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -461,12 +461,13 @@ function generateExtraMetadata(
     });
   }
 
-  Object.keys(node).forEach((key) => {
-    if (key === "inputParameters" && Array.isArray(node.inputParameters)) {
-      node.inputParameters.forEach((inputParameter: any) => {
-        inputParameter.insideParenthesis = true;
-      });
+  if ("inputParameters" in node && Array.isArray(node.inputParameters)) {
+    for (let inputParameter of node.inputParameters) {
+      inputParameter.insideParenthesis = true;
     }
+  }
+
+  Object.keys(node).forEach((key) => {
     if (typeof node[key] === "object") {
       if (Array.isArray(node)) {
         const keyInt = parseInt(key, 10);

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -364,17 +364,19 @@ function handleNodeLocation(
   const apexClass = node["@class"];
   let handlerFn;
   if (apexClass) {
-    const separatorIndex = apexClass.indexOf("$");
-    if (separatorIndex !== -1) {
-      const parentClass = apexClass.substring(0, separatorIndex);
-      if (parentClass in locationGenerationHandler) {
-        handlerFn = locationGenerationHandler[parentClass];
-      }
-    }
     if (apexClass in locationGenerationHandler) {
       handlerFn = locationGenerationHandler[apexClass];
+    } else {
+      const separatorIndex = apexClass.indexOf("$");
+      if (separatorIndex !== -1) {
+        const parentClass = apexClass.slice(0, separatorIndex);
+        if (parentClass in locationGenerationHandler) {
+          handlerFn = locationGenerationHandler[parentClass];
+        }
+      }
     }
   }
+
   if (handlerFn && currentLocation) {
     node.loc = handlerFn(currentLocation, sourceCode, commentNodes, node);
   } else if (handlerFn && node.loc) {

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -462,12 +462,12 @@ function generateExtraMetadata(
   }
 
   if ("inputParameters" in node && Array.isArray(node.inputParameters)) {
-    for (let inputParameter of node.inputParameters) {
+    for (const inputParameter of node.inputParameters) {
       inputParameter.insideParenthesis = true;
     }
   }
 
-  for (let key of Object.keys(node)) {
+  for (const key of Object.keys(node)) {
     if (typeof node[key] === "object") {
       if (Array.isArray(node)) {
         const keyInt = parseInt(key, 10);
@@ -523,6 +523,27 @@ function generateExtraMetadata(
   return nodeLoc;
 }
 
+function getLineNumber(lineIndexes: number[], charIndex: number) {
+  let low = 0;
+  let high = lineIndexes.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const midIndex = lineIndexes[mid] ?? 0;
+    const beforeMidIndex = lineIndexes[mid - 1] ?? 0;
+
+    if (midIndex >= charIndex && beforeMidIndex < charIndex) {
+      return mid;
+    }
+
+    if (midIndex < charIndex) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return -1;
+}
+
 // For each node, the jorje compiler gives us its line and its index within
 // that line; however we use this method to resolve that line index to a global
 // index of that node within the source code. That allows us to use prettier
@@ -555,31 +576,12 @@ function resolveLineIndexes(node: any, lineIndexes: number[]) {
     }
   }
 
-  for (let key of Object.keys(node)) {
+  for (const key of Object.keys(node)) {
     if (typeof node[key] === "object") {
       node[key] = resolveLineIndexes(node[key], lineIndexes);
     }
   }
   return node;
-}
-
-function getLineNumber(lineIndexes: number[], charIndex: number) {
-  let low = 0;
-  let high = lineIndexes.length - 1;
-  while (low <= high) {
-    let mid = Math.floor((low + high) / 2);
-    const midIndex = lineIndexes[mid] ?? 0;
-    const beforeMidIndex = lineIndexes[mid - 1] ?? 0;
-
-    if (midIndex >= charIndex && beforeMidIndex < charIndex) {
-      return mid;
-    } else if (midIndex < charIndex) {
-      low = mid + 1;
-    } else {
-      high = mid - 1;
-    }
-  }
-  return -1;
 }
 
 // Get a map of line number to the index of its first character

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -467,7 +467,7 @@ function generateExtraMetadata(
     }
   }
 
-  Object.keys(node).forEach((key) => {
+  for (let key of Object.keys(node)) {
     if (typeof node[key] === "object") {
       if (Array.isArray(node)) {
         const keyInt = parseInt(key, 10);
@@ -492,29 +492,31 @@ function generateExtraMetadata(
             currentChildNode.loc &&
             nextChildNode.loc.startLine === currentChildNode.loc.endLine
           ) {
-            node[keyInt].isNextStatementOnSameLine = true;
+            currentChildNode.isNextStatementOnSameLine = true;
           }
         }
       }
+
       generateExtraMetadata(
         node[key],
         emptyLineLocations,
         allowTrailingEmptyLineWithin,
       );
     }
-  });
+  }
 
   const nodeLoc = getNodeLocation(node);
   if (
     apexClass &&
     nodeLoc &&
     allowTrailingEmptyLine &&
+    trailingEmptyLineAllowed &&
     !node.isLastNodeInArray &&
     !node.isNextStatementOnSameLine
   ) {
     const nextLine = nodeLoc.endLine + 1;
     const nextEmptyLine = emptyLineLocations.indexOf(nextLine);
-    if (trailingEmptyLineAllowed && nextEmptyLine !== -1) {
+    if (nextEmptyLine !== -1) {
       node.trailingEmptyLine = true;
     }
   }
@@ -553,11 +555,11 @@ function resolveLineIndexes(node: any, lineIndexes: number[]) {
     }
   }
 
-  Object.keys(node).forEach((key) => {
+  for (let key of Object.keys(node)) {
     if (typeof node[key] === "object") {
       node[key] = resolveLineIndexes(node[key], lineIndexes);
     }
-  });
+  }
   return node;
 }
 

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -462,12 +462,12 @@ function generateExtraMetadata(
   }
 
   if ("inputParameters" in node && Array.isArray(node.inputParameters)) {
-    for (const inputParameter of node.inputParameters) {
+    node.inputParameters.forEach((inputParameter: any) => {
       inputParameter.insideParenthesis = true;
-    }
+    });
   }
 
-  for (const key of Object.keys(node)) {
+  Object.keys(node).forEach((key) => {
     if (typeof node[key] === "object") {
       if (Array.isArray(node)) {
         const keyInt = parseInt(key, 10);
@@ -503,7 +503,7 @@ function generateExtraMetadata(
         allowTrailingEmptyLineWithin,
       );
     }
-  }
+  });
 
   const nodeLoc = getNodeLocation(node);
   if (
@@ -576,11 +576,11 @@ function resolveLineIndexes(node: any, lineIndexes: number[]) {
     }
   }
 
-  for (const key of Object.keys(node)) {
+  Object.keys(node).forEach((key) => {
     if (typeof node[key] === "object") {
       node[key] = resolveLineIndexes(node[key], lineIndexes);
     }
-  }
+  });
   return node;
 }
 

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -382,27 +382,31 @@ function handleNodeLocation(
   } else if (handlerFn && node.loc) {
     node.loc = handlerFn(node.loc, sourceCode, commentNodes, node);
   }
-  if (!node.loc) {
+
+  const nodeLoc = node.loc;
+  if (!nodeLoc) {
     delete node.loc;
-  } else if (node.loc && currentLocation) {
-    if (node.loc.startIndex > currentLocation.startIndex) {
-      node.loc.startIndex = currentLocation.startIndex;
+  } else if (nodeLoc && currentLocation) {
+    if (nodeLoc.startIndex > currentLocation.startIndex) {
+      nodeLoc.startIndex = currentLocation.startIndex;
     } else {
-      currentLocation.startIndex = node.loc.startIndex;
+      currentLocation.startIndex = nodeLoc.startIndex;
     }
-    if (node.loc.endIndex < currentLocation.endIndex) {
-      node.loc.endIndex = currentLocation.endIndex;
+    if (nodeLoc.endIndex < currentLocation.endIndex) {
+      nodeLoc.endIndex = currentLocation.endIndex;
     } else {
-      currentLocation.endIndex = node.loc.endIndex;
+      currentLocation.endIndex = nodeLoc.endIndex;
     }
   }
+
   if (currentLocation) {
     return { ...currentLocation };
   }
-  if (node.loc) {
+
+  if (nodeLoc) {
     return {
-      startIndex: node.loc.startIndex,
-      endIndex: node.loc.endIndex,
+      startIndex: nodeLoc.startIndex,
+      endIndex: nodeLoc.endIndex,
     };
   }
   return null;

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -345,8 +345,9 @@ function handleNodeLocation(
 ) {
   let currentLocation: MinimalLocation | undefined;
   Object.keys(node).forEach((key) => {
-    if (typeof node[key] === "object") {
-      const location = handleNodeLocation(node[key], sourceCode, commentNodes);
+    const value = node[key];
+    if (typeof value === "object") {
+      const location = handleNodeLocation(value, sourceCode, commentNodes);
       if (location && currentLocation) {
         if (currentLocation.startIndex > location.startIndex) {
           currentLocation.startIndex = location.startIndex;
@@ -354,8 +355,7 @@ function handleNodeLocation(
         if (currentLocation.endIndex < location.endIndex) {
           currentLocation.endIndex = location.endIndex;
         }
-      }
-      if (location && !currentLocation) {
+      } else if (location && !currentLocation) {
         currentLocation = location;
       }
     }

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -382,8 +382,7 @@ function handleNodeLocation(
   }
   if (!node.loc) {
     delete node.loc;
-  }
-  if (node.loc && currentLocation) {
+  } else if (node.loc && currentLocation) {
     if (node.loc.startIndex > currentLocation.startIndex) {
       node.loc.startIndex = currentLocation.startIndex;
     } else {
@@ -448,10 +447,9 @@ function generateExtraMetadata(
   if (apexClass === APEX_TYPES.SEARCH || apexClass === APEX_TYPES.QUERY) {
     node.forcedHardline = node.loc.startLine !== node.loc.endLine;
   }
-
   // jorje parses all `if` and `else if` blocks into `ifBlocks`, so we add
   // `ifBlockIndex` into the node for handling code to differentiate them.
-  if (apexClass === APEX_TYPES.IF_ELSE_BLOCK) {
+  else if (apexClass === APEX_TYPES.IF_ELSE_BLOCK) {
     node.ifBlocks.forEach((ifBlock: jorje.IfBlock, index: number) => {
       (ifBlock as EnrichedIfBlock).ifBlockIndex = index;
     });


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Up to 60% faster parsing. The biggest improvement is for larger files.
The changes are around resolving the line indexes from character indexes and so most changes are in `resolvelineindexes`.
I implemented a binary search to find the line numbers for the given `startIndex` and `endIndex`

## Test numbers

**95 line Apex class**
before: 1087.75 ms
after: 1068.5 ms

**528 line Apex class**
before: 190 ms
after: 156.5 ms

**11_230 line Apex class**
before: 5710.25 ms
after: 3434.75 ms

## Images
Produced using `node --inspect-brk` and chrome profiling.
The Apex Class used was 11_230 lines long

**Before**
![prettier-apex-perf-before](https://github.com/user-attachments/assets/ab824444-afcf-43d5-8ec9-6ccbc033a4aa)

**After**
![prettier-apex-perf-after](https://github.com/user-attachments/assets/c0a34434-6466-465d-99f2-8b27faf7bebb)


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.

This was a perf improvement but I did testing and have attached before and after images of the flame chart as well as before and after numbers of time taken.

- [X] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [X] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).