### PR TITLE
Fix #1706 - Native Executable not usable in NixOS Linux environment

### DIFF
--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -200,6 +200,9 @@ jobs:
           path: |
             .nx
           key: ${{ matrix.os }}-nx-build-native-${{ hashFiles('packages/apex-ast-serializer/parser/**/*.java', 'packages/apex-ast-serializer/parser/**/*.properties', 'packages/apex-ast-serializer/parser/build.gradle', 'packages/apex-ast-serializer/libs/*.jar', 'packages/apex-ast-serializer/tools/build-native-binary.mjs') }}
+      - name: Build Linux musl toolchain
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm nx run apex-ast-serializer:build:musl
       - name: Build native executable
         env:
           # https://nx.dev/troubleshooting/unknown-local-cache

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out
 packages/prettier-plugin-apex/tests/local_only
 packages/prettier-plugin-apex/vendor
 packages/apex-ast-serializer/parser/src/pgo-profiles
+packages/apex-ast-serializer/musl-toolchain
 packages/@prettier-apex/apex-ast-serializer*/apex-ast-serializer*
 
 .nx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix native executable not usable in NixOS Linux environment ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1706)).
+
 # 2.2.1
 
 - Fix native executable not spawned correctly in path with special characters ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1702)).

--- a/packages/apex-ast-serializer/parser/build.gradle
+++ b/packages/apex-ast-serializer/parser/build.gradle
@@ -149,6 +149,13 @@ graalvmNative {
       sharedLibrary = false
       buildArgs.add('--features=net.dangmai.serializer.RuntimeReflectionRegistrationFeature')
       buildArgs.addAll(application.applicationDefaultJvmArgs)
+      // Certain Linux distribution doesn't allow dynamic-linked binaries to be
+      // run, for example, NixOS, so we need to build a static binary.
+      if (System.getProperty('os.name').toLowerCase().contains('linux') && System.getProperty('os.arch').contains('amd64')) {
+        environmentVariables.put("PATH", file('../musl-toolchain/bin').absolutePath + ":" + System.getenv("PATH"))
+        buildArgs.add('--static');
+        buildArgs.add('--libc=musl');
+      }
     }
   }
 }

--- a/packages/apex-ast-serializer/project.json
+++ b/packages/apex-ast-serializer/project.json
@@ -6,9 +6,7 @@
   "namedInputs": {
     "gradle": ["{projectRoot}/**/build.gradle"],
     "default": ["{projectRoot}/**/*.java", "{projectRoot}/**/*.properties"],
-    "native": [
-      "{projectRoot}/packages/apex-ast-serializer/tools/build-native-binary.mjs"
-    ]
+    "native": ["{projectRoot}/tools/build-native-binary.mjs"]
   },
   "targets": {
     "build": {
@@ -31,6 +29,16 @@
       "options": {
         "cwd": "packages/apex-ast-serializer",
         "command": "node tools/build-native-binary.mjs"
+      }
+    },
+    "build:musl": {
+      "executor": "nx:run-commands",
+      "inputs": ["{projectRoot}/tools/build-musl-toolchain.sh"],
+      "outputs": ["{projectRoot}/musl-toolchain"],
+      "cache": true,
+      "options": {
+        "cwd": "packages/apex-ast-serializer",
+        "command": "./tools/build-musl-toolchain.sh"
       }
     },
     "test": {

--- a/packages/apex-ast-serializer/tools/build-musl-toolchain.sh
+++ b/packages/apex-ast-serializer/tools/build-musl-toolchain.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Adapted from https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/
+
+# Specify an installation directory for musl:
+export MUSL_HOME=$PWD/musl-toolchain
+
+# Download musl and zlib sources:
+curl -O https://musl.libc.org/releases/musl-1.2.4.tar.gz
+curl -O https://zlib.net/fossils/zlib-1.2.13.tar.gz
+
+# Build musl from source
+tar -xzvf musl-1.2.4.tar.gz
+pushd musl-1.2.4
+./configure --prefix=$MUSL_HOME --static
+# The next operation may require privileged access to system resources, so use sudo
+# sudo make && make install
+make && make install
+popd
+
+# Install a symlink for use by native-image
+ln -sf $MUSL_HOME/bin/musl-gcc $MUSL_HOME/bin/x86_64-linux-musl-gcc
+
+# Extend the system path and confirm that musl is available by printing its version
+export PATH="$MUSL_HOME/bin:$PATH"
+x86_64-linux-musl-gcc --version
+
+# Build zlib with musl from source and install into the MUSL_HOME directory
+tar -xzvf zlib-1.2.13.tar.gz
+pushd zlib-1.2.13
+CC=musl-gcc ./configure --prefix=$MUSL_HOME --static
+make && make install
+popd
+
+rm -rf musl-1.2.4.tar.gz musl-1.2.4 zlib-1.2.13.tar.gz zlib-1.2.13


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
