### PR TITLE
Fix #1822 - Linux x64 executable not being able to run in macOS Docker on Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix Linux native executables having low stack depth ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1809), [issue](https://github.com/dangmai/prettier-plugin-apex/issues/1733)).
+- Fix Linux native executables not being able to run in macOS Docker on Apple Silicon ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1822)).
 - Fix duplicate newlines after last trailing comment in document ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1777)).
 
 # 2.2.2

--- a/packages/apex-ast-serializer/parser/build.gradle
+++ b/packages/apex-ast-serializer/parser/build.gradle
@@ -155,6 +155,7 @@ graalvmNative {
         environmentVariables.put("PATH", file('../musl-toolchain/bin').absolutePath + ":" + System.getenv("PATH"))
         buildArgs.add('--static');
         buildArgs.add('--libc=musl');
+        buildArgs.add('-march=compatibility');
         // #1733, #1809 - We need to manually increase stack size for musl static binary,
         // otherwise we will run into stack overflow issues.
         // https://github.com/oracle/graal/issues/3398

--- a/packages/apex-ast-serializer/parser/build.gradle
+++ b/packages/apex-ast-serializer/parser/build.gradle
@@ -155,6 +155,9 @@ graalvmNative {
         environmentVariables.put("PATH", file('../musl-toolchain/bin').absolutePath + ":" + System.getenv("PATH"))
         buildArgs.add('--static');
         buildArgs.add('--libc=musl');
+        // #1822 - By default, the native executable can't be run in Docker x64
+        // images on macOS with M-chips. We set the compatibility flag to ensure
+        // it can be run in that context, although it may not be as optimized.
         buildArgs.add('-march=compatibility');
         // #1733, #1809 - We need to manually increase stack size for musl static binary,
         // otherwise we will run into stack overflow issues.


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Closes #1822 
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [ ] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
