### PR TITLE
Pin @nx/shared-fs-cache to 5.0.2 to fix native build CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
-    "@nx/shared-fs-cache": "5.0.3",
+    "@nx/shared-fs-cache": "5.0.2",
     "@tsconfig/node20": "20.1.9",
     "@types/node": "20.14.8",
     "@types/semver": "7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 2.4.13
         version: 2.4.13
       '@nx/shared-fs-cache':
-        specifier: 5.0.3
-        version: 5.0.3(nx@22.7.0)
+        specifier: 5.0.2
+        version: 5.0.2(nx@22.7.0)
       '@tsconfig/node20':
         specifier: 20.1.9
         version: 20.1.9
@@ -477,71 +477,71 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nx/devkit@22.6.5':
-    resolution: {integrity: sha512-9kvAI+kk2pfEXLqS8OyjI9XvWmp+Gdn7jPfxDAz8BOqxMyPy3p5hYl+jc4TIsLOWunAFl8azqrcYsHzEpaWCIA==}
+  '@nx/devkit@22.0.3':
+    resolution: {integrity: sha512-98Iq6+FIrAEv7ZK3n86Nr8zUZ20394fpyJBBhvQJiywH+JRonk7JWY5tUaSuL8kfY8vM+WCnFoWHJ+2Hsgw9EA==}
     peerDependencies:
       nx: '>= 21 <= 23 || ^22.0.0-0'
 
-  '@nx/key-darwin-arm64@5.0.3':
-    resolution: {integrity: sha512-CFykHMe21X0BUIlrT6jJGctbxSnG0QxzSsnqtIV+/K/ZWTCQRDXkRmibucZR7A7wEa4r5G/3wLP+Qb7mvAhpgw==}
+  '@nx/key-darwin-arm64@5.0.2':
+    resolution: {integrity: sha512-gIe8Cl0sE/BZQxvrmam7tZg3hKbBn7Skt25yRMzf6E8UajomG8IGefDv7wM8SVOTA8495viAnqbidM5iNzq4gQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@nx/key-darwin-x64@5.0.3':
-    resolution: {integrity: sha512-CIOzAN74wzRLw3bA8JXHze5vB7XLld90il4NNC7aR8hCyFgs3pjW6N/KpRPbfTUOdxq+dnior3IiBzDCWvKeKw==}
+  '@nx/key-darwin-x64@5.0.2':
+    resolution: {integrity: sha512-XcCT+GYIJPGxHQV90nd7aphuEbe2VLDP53aaXiy1r9RO7XE9AJ8yn4kn5RY81v+7nbBp0/UxM7N44Td2xOrtgw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@nx/key-linux-arm-gnueabihf@5.0.3':
-    resolution: {integrity: sha512-YTgGW6jiYeh1zK7/eLwktqo9/a9kJMVsMPMXucAG3IUrgdhNW1ciiGoeSNVzCu/6io4yzVJCxJ5xTg+A4nYsHA==}
+  '@nx/key-linux-arm-gnueabihf@5.0.2':
+    resolution: {integrity: sha512-XU3Q4Mv0nhjdQmAdbdoPRryWPghaLAo23jRB7Zp7IoqbS887gWwoJF2sz3tBZU9FSRvPvEeYBYlSJRH/9PBoLA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@nx/key-linux-arm64-gnu@5.0.3':
-    resolution: {integrity: sha512-/3VpKgPB3svPN07P6/Bz52JuKUhufMm69djsS9YAPoyTz8wQ99IfDsUJSnCEZ3d9wWlwPNEZXHtQeApW78rNOQ==}
+  '@nx/key-linux-arm64-gnu@5.0.2':
+    resolution: {integrity: sha512-lCXDSPgMCx2qawxmHXP0BjRkGN9Tku8xUS3UsjiEDdQi+2uHgWS73lsyehYziwDKxqzxMXoPgZHpkU5VLQDFcA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@nx/key-linux-arm64-musl@5.0.3':
-    resolution: {integrity: sha512-vxmxZ49GgHfoEn5/9Gkt6UivBE072F6BSEdQSJFOQMxiWTBE039I/2/7+PqJ67+gFfjlJtlBV8h5vXF2w4N+Bg==}
+  '@nx/key-linux-arm64-musl@5.0.2':
+    resolution: {integrity: sha512-7FOF1Cnb5KL/Vy8zlFwUYODqejMRQQ1Lwds40G2GEElei+HHwwJQxxSl1gnuUu6yuCKucPEFXj47Xr+4sBuTiQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@nx/key-linux-x64-gnu@5.0.3':
-    resolution: {integrity: sha512-r+DzxgHcqi4xOBS7gxjNBAYRgMzBxp25AgPs+c+wkKkCZW+hdULe9yfhHG1rbFxphSc414wymVpPuxQ3IGvn0g==}
+  '@nx/key-linux-x64-gnu@5.0.2':
+    resolution: {integrity: sha512-t3IpOwrvHyOlOZI6cL5yLfGOe3BIU4De5Hg0leHXEvsC2ooECr9kOl8wGB+CuurI8SbjcwKSUSMcqJY4noRVHw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@nx/key-linux-x64-musl@5.0.3':
-    resolution: {integrity: sha512-aqOPV+XCIgkNtfC1XGsy/Em/UKdDdFeASzJl9xpnP1+iCgGTh8lGHa2OW9r29W8AsrKz1+ujnsl3eMf/uuzaqg==}
+  '@nx/key-linux-x64-musl@5.0.2':
+    resolution: {integrity: sha512-0LFPyr9qSKGrGt2LXPdnCwCjZoTPnF+tN4DRnaD+TWx7gNjvbqbdUq97AbbhI8VFZCM00ipQVXo0MehefS+SEA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@nx/key-win32-arm64-msvc@5.0.3':
-    resolution: {integrity: sha512-Xc9G39PhgrSH33aMJFKu7KogBGjhdI4I7IKRpqDODEuVlirt3kRvPg31v0Ai6nhotcwMvU1TpK70ndW1IT/t0Q==}
+  '@nx/key-win32-arm64-msvc@5.0.2':
+    resolution: {integrity: sha512-abrzvc5v30KqQAjcJy/1z60Uj8kgf4iIHnle1zdc6RM617CSLx4z6TAwU8YIYPLtR9l39cRMUmCd6EScGHIiZg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@nx/key-win32-x64-msvc@5.0.3':
-    resolution: {integrity: sha512-LO4rEnEsFHjQtavEVjdfaWwUJT8NQOERHA0O4m6EYuazcGbtwio2AfQuy9MBMdKywXhmnGNR5U0wyC2hb5iXrA==}
+  '@nx/key-win32-x64-msvc@5.0.2':
+    resolution: {integrity: sha512-A/YmSPsbMIsM8pHtQIeebqMf31Jnri3OVNFlLe32jhLmv9i2Y3QDwYSAicLEjIu6R9WaU2lfJFg3gLCqf5fvgA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@nx/key@5.0.3':
-    resolution: {integrity: sha512-tCCOT4SkaR2lGFYjbEFZY5lQ8gP7F0tJo3puT+q7pectoMCfaIB+ZnM1OaAYE6tcxD4AkqPqQpiJ2/9xNa9wUg==}
+  '@nx/key@5.0.2':
+    resolution: {integrity: sha512-wFLjrTapHdGhjEdK6jTG41khBwXPrwhR+OGWcB4u52DMD1JYV/ZHi3hMXvS6VFFwQJ6o2M76uYBWK9OSLZXcCQ==}
     engines: {node: '>= 10'}
 
   '@nx/nx-darwin-arm64@22.7.0':
@@ -598,8 +598,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@nx/shared-fs-cache@5.0.3':
-    resolution: {integrity: sha512-A4bGiH4aHpvfFrMjzZYrJWkfYOyDn+b7hjk84FWTiclTOQQ8lSeZ0fRMySbzNQ54cVKxIrNRkaTd8XEdjFLCuQ==}
+  '@nx/shared-fs-cache@5.0.2':
+    resolution: {integrity: sha512-q6665rOfr1+etT31xZOmW6MpBnasiN4bEz441JSbgtfepfbhD2JESUIWMzJuR/SkGrGrlB1alkhekqScQ3kTbQ==}
     peerDependencies:
       nx: '>= 18 < 23'
 
@@ -832,6 +832,9 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -840,11 +843,17 @@ packages:
     peerDependencies:
       axios: 0.x || 1.x
 
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axios@1.15.1:
     resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.3:
     resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
@@ -859,6 +868,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.2:
     resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
@@ -989,6 +1001,11 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   ejs@5.0.1:
     resolution: {integrity: sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==}
     engines: {node: '>=0.12.18'}
@@ -1066,6 +1083,9 @@ packages:
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
+
+  filelist@1.0.6:
+    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1227,6 +1247,11 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   java-parser@3.0.1:
     resolution: {integrity: sha512-sDIR7u9b7O2JViNUxiZRhnRz7URII/eE7g2B+BmGxDeS6Ex3OYAcCyz5oh0H4LQ+hL/BS8OJTz8apMy9xtGmrQ==}
@@ -1399,6 +1424,14 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -1501,6 +1534,9 @@ packages:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -2065,62 +2101,62 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nx/devkit@22.6.5(nx@22.7.0)':
+  '@nx/devkit@22.0.3(nx@22.7.0)':
     dependencies:
       '@zkochan/js-yaml': 0.0.7
-      ejs: 5.0.1
+      ejs: 3.1.10
       enquirer: 2.3.6
-      minimatch: 10.2.4
+      minimatch: 9.0.3
       nx: 22.7.0
       semver: 7.7.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/key-darwin-arm64@5.0.3':
+  '@nx/key-darwin-arm64@5.0.2':
     optional: true
 
-  '@nx/key-darwin-x64@5.0.3':
+  '@nx/key-darwin-x64@5.0.2':
     optional: true
 
-  '@nx/key-linux-arm-gnueabihf@5.0.3':
+  '@nx/key-linux-arm-gnueabihf@5.0.2':
     optional: true
 
-  '@nx/key-linux-arm64-gnu@5.0.3':
+  '@nx/key-linux-arm64-gnu@5.0.2':
     optional: true
 
-  '@nx/key-linux-arm64-musl@5.0.3':
+  '@nx/key-linux-arm64-musl@5.0.2':
     optional: true
 
-  '@nx/key-linux-x64-gnu@5.0.3':
+  '@nx/key-linux-x64-gnu@5.0.2':
     optional: true
 
-  '@nx/key-linux-x64-musl@5.0.3':
+  '@nx/key-linux-x64-musl@5.0.2':
     optional: true
 
-  '@nx/key-win32-arm64-msvc@5.0.3':
+  '@nx/key-win32-arm64-msvc@5.0.2':
     optional: true
 
-  '@nx/key-win32-x64-msvc@5.0.3':
+  '@nx/key-win32-x64-msvc@5.0.2':
     optional: true
 
-  '@nx/key@5.0.3':
+  '@nx/key@5.0.2':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.12
-      axios: 1.15.0
-      axios-retry: 4.5.0(axios@1.15.0)
+      axios: 1.13.6
+      axios-retry: 4.5.0(axios@1.13.6)
       chalk: 4.1.2
       enquirer: 2.4.1
       ora: 5.4.1
     optionalDependencies:
-      '@nx/key-darwin-arm64': 5.0.3
-      '@nx/key-darwin-x64': 5.0.3
-      '@nx/key-linux-arm-gnueabihf': 5.0.3
-      '@nx/key-linux-arm64-gnu': 5.0.3
-      '@nx/key-linux-arm64-musl': 5.0.3
-      '@nx/key-linux-x64-gnu': 5.0.3
-      '@nx/key-linux-x64-musl': 5.0.3
-      '@nx/key-win32-arm64-msvc': 5.0.3
-      '@nx/key-win32-x64-msvc': 5.0.3
+      '@nx/key-darwin-arm64': 5.0.2
+      '@nx/key-darwin-x64': 5.0.2
+      '@nx/key-linux-arm-gnueabihf': 5.0.2
+      '@nx/key-linux-arm64-gnu': 5.0.2
+      '@nx/key-linux-arm64-musl': 5.0.2
+      '@nx/key-linux-x64-gnu': 5.0.2
+      '@nx/key-linux-x64-musl': 5.0.2
+      '@nx/key-win32-arm64-msvc': 5.0.2
+      '@nx/key-win32-x64-msvc': 5.0.2
     transitivePeerDependencies:
       - debug
 
@@ -2154,10 +2190,10 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.7.0':
     optional: true
 
-  '@nx/shared-fs-cache@5.0.3(nx@22.7.0)':
+  '@nx/shared-fs-cache@5.0.2(nx@22.7.0)':
     dependencies:
-      '@nx/devkit': 22.6.5(nx@22.7.0)
-      '@nx/key': 5.0.3
+      '@nx/devkit': 22.0.3(nx@22.7.0)
+      '@nx/key': 5.0.2
       nx: 22.7.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -2346,12 +2382,22 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
-  axios-retry@4.5.0(axios@1.15.0):
+  axios-retry@4.5.0(axios@1.13.6):
     dependencies:
-      axios: 1.15.0
+      axios: 1.13.6
       is-retry-allowed: 2.2.0
+
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axios@1.15.0:
     dependencies:
@@ -2369,6 +2415,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.3: {}
 
   balanced-match@4.0.4: {}
@@ -2380,6 +2428,10 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.2:
     dependencies:
@@ -2508,6 +2560,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
+
   ejs@5.0.1: {}
 
   emoji-regex@8.0.0: {}
@@ -2600,6 +2656,10 @@ snapshots:
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  filelist@1.0.6:
+    dependencies:
+      minimatch: 5.1.9
 
   fill-range@7.1.1:
     dependencies:
@@ -2731,6 +2791,12 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.6
+      picocolors: 1.1.1
 
   java-parser@3.0.1:
     dependencies:
@@ -2866,6 +2932,14 @@ snapshots:
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minimatch@9.0.3:
+    dependencies:
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 
@@ -3078,6 +3152,8 @@ snapshots:
       typescript: 6.0.3
 
   prettier@3.8.3: {}
+
+  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 


### PR DESCRIPTION
The scheduled CI runs have been failing since April 24 because `@nx/shared-fs-cache@5.0.3` introduced a regression in its bundled `@nx/key` native binary.

The NX daemon panics immediately on startup with an assertion failure in the Rust `generic-array` crate:

```
thread 'tokio-runtime-worker' panicked at generic-array-0.14.7/src/lib.rs:572:9:
assertion `left == right` failed
  left: 36
 right: 32
Command was killed with SIGABRT (Aborted): nx run apex-ast-serializer:build:musl
```

This aborts any `nx run` invocation before the target script even starts — so the Linux musl toolchain build and macOS native binary build both fail immediately. Since `build-native-executables` uses the default `fail-fast`, one platform failure cascades and cancels all the others.

The regression was introduced in `@nx/key@5.0.3` (pulled in transitively by `@nx/shared-fs-cache@5.0.3`). The April 23 scheduled run passed with `@nx/shared-fs-cache@5.0.2`; every run after `5.0.3` landed has failed.

This PR pins back to `5.0.2` and regenerates the lockfile. Will re-upgrade once a fixed release is available upstream.