### PR TITLE
docs: add CLAUDE.md and expand apex-ast-serializer README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# prettier-plugin-apex
+
+A Prettier plugin for Salesforce Apex. It is a pnpm monorepo orchestrated with Nx. The plugin delegates parsing to a Java component (`apex-ast-serializer`) that wraps Salesforce's proprietary `jorje` parser, then uses Prettier's doc IR to format the resulting AST.
+
+## Read these first
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — full dev setup, quickstart, and workflow
+- [packages/prettier-plugin-apex/README.md](packages/prettier-plugin-apex/README.md) — plugin usage and options
+- [packages/apex-ast-serializer/README.md](packages/apex-ast-serializer/README.md) — Java parser, jorje dependency, type generation
+
+## Monorepo structure
+
+```
+packages/
+  prettier-plugin-apex/      # TypeScript plugin (parser.ts, printer.ts, comments.ts)
+  apex-ast-serializer/       # Java/Gradle parser wrapping jorje
+  playground/                # React/Vite web playground (deployed on Render)
+  @prettier-apex/            # Platform-specific native binary packages
+```
+
+## Key commands
+
+```bash
+# Start HTTP parsing server (needed for built-in mode; VSCode task does this automatically)
+pnpm nx run prettier-plugin-apex:start-server
+
+# Run unit tests (built-in HTTP server mode — preferred for local dev)
+pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
+
+# Run unit tests (native binary mode)
+pnpm nx run prettier-plugin-apex:test:parser --configuration native
+
+# Update snapshots
+pnpm nx run prettier-plugin-apex:test:parser --configuration built-in -u
+
+# Run with AST comparison (validates semantic equivalence after formatting)
+AST_COMPARE=true pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
+
+# Lint
+pnpm nx run prettier-plugin-apex:lint
+```
+
+## Agent workflow rules
+
+- **Before pushing**: run `pnpm nx run prettier-plugin-apex:lint` and fix any issues, then run the unit tests (`test:parser --configuration built-in`). Both must pass.
+- **After completing a major feature**: verify that CLAUDE.md and the relevant README files still accurately describe the project.

--- a/packages/apex-ast-serializer/README.md
+++ b/packages/apex-ast-serializer/README.md
@@ -7,6 +7,16 @@ using the jorje Apex parser distributed by Salesforce.
 
 The result is printed out to `stdout` as either a JSON or XML object.
 
+## The jorje Dependency
+
+This project depends on `apex-jorje-lsp.jar`, Salesforce's proprietary internal Apex parser (distributed as part of the [Salesforce VSCode extension](https://github.com/forcedotcom/salesforcedx-vscode)). It was reverse-engineered to expose a full AST suitable for formatting.
+
+The JAR is stored (minimized) at `libs/apex-jorje-lsp.jar`. A daily CI workflow (`update-jorje.yml`) checks for new versions and opens a PR automatically. To manually update it, run `tools/create-jorje-jar.sh`.
+
+The TypeScript type definitions for the Apex AST (`packages/prettier-plugin-apex/vendor/typings/jorje.d.ts`) are **fully generated** by the Gradle `typescript-generator` plugin — they are produced automatically as part of the `installDist` build step and should not be edited by hand.
+
+Do not replace or upgrade `apex-jorje-lsp.jar` casually — changes may affect the AST structure and require updates to `printer.ts` and the generated typings.
+
 ## Building
 
 This project requires Java >= 17 to compile, and specifically [GraalVM](https://www.graalvm.org/) to build native images.


### PR DESCRIPTION
Adds CLAUDE.md at the repo root to orient Claude Code agents with project structure, key commands, and workflow rules (lint + test before push, keep docs updated after major features).

Also expands the apex-ast-serializer README with a section documenting the jorje dependency, how the JAR is managed, and that jorje.d.ts is auto-generated by the Gradle typescript-generator plugin.

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [ ] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
