### PR TITLE
Let Renovate manage musl and zlib versions in toolchain script

### DIFF
--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -13,6 +13,19 @@ permissions:
   id-token: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      musl-script: ${{ steps.filter.outputs.musl-script }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: dorny/paths-filter@v3.0.2
+        id: filter
+        with:
+          filters: |
+            musl-script:
+              - 'packages/apex-ast-serializer/tools/build-musl-toolchain.sh'
+
   functional-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -143,7 +156,8 @@ jobs:
 
   build-native-executables:
     name: Build Native Executables
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags')
+    needs: changes
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags') || needs.changes.outputs.musl-script == 'true'
     strategy:
       matrix:
         os:

--- a/packages/apex-ast-serializer/tools/build-musl-toolchain.sh
+++ b/packages/apex-ast-serializer/tools/build-musl-toolchain.sh
@@ -4,16 +4,21 @@ set -euxo pipefail
 
 # Adapted from https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/
 
+# renovate: datasource=git-tags depName=musl packageName=https://git.musl-libc.org/cgit/musl extractVersion=^v(?<version>.+)$
+MUSL_VERSION="1.2.4"
+# renovate: datasource=github-tags depName=zlib packageName=madler/zlib extractVersion=^v(?<version>.+)$
+ZLIB_VERSION="1.2.13"
+
 # Specify an installation directory for musl:
 export MUSL_HOME=$PWD/musl-toolchain
 
 # Download musl and zlib sources:
-curl -O https://musl.libc.org/releases/musl-1.2.4.tar.gz
-curl -O https://zlib.net/fossils/zlib-1.2.13.tar.gz
+curl -O https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz
+curl -LO https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz
 
 # Build musl from source
-tar -xzvf musl-1.2.4.tar.gz
-pushd musl-1.2.4
+tar -xzvf musl-${MUSL_VERSION}.tar.gz
+pushd musl-${MUSL_VERSION}
 ./configure --prefix=$MUSL_HOME --static
 # The next operation may require privileged access to system resources, so use sudo
 # sudo make && make install
@@ -28,10 +33,10 @@ export PATH="$MUSL_HOME/bin:$PATH"
 x86_64-linux-musl-gcc --version
 
 # Build zlib with musl from source and install into the MUSL_HOME directory
-tar -xzvf zlib-1.2.13.tar.gz
-pushd zlib-1.2.13
+tar -xzvf zlib-${ZLIB_VERSION}.tar.gz
+pushd zlib-${ZLIB_VERSION}
 CC=musl-gcc ./configure --prefix=$MUSL_HOME --static
 make && make install
 popd
 
-rm -rf musl-1.2.4.tar.gz musl-1.2.4 zlib-1.2.13.tar.gz zlib-1.2.13
+rm -rf musl-${MUSL_VERSION}.tar.gz musl-${MUSL_VERSION} zlib-${ZLIB_VERSION}.tar.gz zlib-${ZLIB_VERSION}

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,14 @@
       matchStrings: [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
       ]
+    },
+    {
+      customType: "regex",
+      description: "Update _VERSION variables in shell scripts",
+      managerFilePatterns: ["/\\.sh$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION=\"(?<currentValue>[^\"]+)\""
+      ]
     }
   ],
   packageRules: [
@@ -55,6 +63,20 @@
       groupName: "typescript-generator",
       additionalBranchPrefix: "",
       matchPackageNames: ["/typescript-generator/"]
+    },
+    {
+      // Bumps to musl or zlib must be validated by the static Linux build
+      // before merging. Use Renovate-managed automerge in PR mode (instead
+      // of platform automerge with branch automerge) so Renovate explicitly
+      // waits for the build-native-executables check to report green.
+      description: "Wait for the static Linux build before automerging musl/zlib",
+      matchPackageNames: [
+        "https://git.musl-libc.org/cgit/musl",
+        "madler/zlib"
+      ],
+      platformAutomerge: false,
+      automergeType: "pr",
+      automerge: true
     }
   ]
 }


### PR DESCRIPTION
Move the hardcoded `musl-1.2.4` and `zlib-1.2.13` strings out of `build-musl-toolchain.sh` into top-of-file `MUSL_VERSION` / `ZLIB_VERSION` variables annotated with Renovate `# renovate:` comments, so Renovate can bump them automatically. Datasources picked for "official-ish" upstream:

- musl: `git-tags` against `https://git.musl-libc.org/cgit/musl` (the canonical cgit Rich Felker maintains).
- zlib: `github-tags` against `madler/zlib`.

Both upstreams tag with a `v` prefix, so each annotation also passes `extractVersion=^v(?<version>.+)$`.

Two supporting changes that came out of doing this safely:

- The zlib download URL has been moved from `zlib.net/fossils/...` (which only hosts *superseded* releases — would 404 the moment Renovate bumps to a newer version) to `github.com/madler/zlib/releases/download/v$ZLIB_VERSION/...`. Stable across versions.
- `renovate.json5` gets a second `customManager` for shell-script `_VERSION` variables, mirroring the existing Dockerfile one.

For CI: `build-native-executables` currently only runs on schedule / dispatch / tag pushes, so a Renovate PR bumping musl or zlib wouldn't actually validate the script. Added a small `dorny/paths-filter` job that flags PRs touching `build-musl-toolchain.sh`, and the existing native-build job now also fires when that filter matches. So the static Linux build runs end-to-end on the bump PR before merge.

Automerge stays on for these deps, but with a wrinkle: GitHub's branch-protection logic treats *skipped* required checks as passing, so you can't naively make the build a "required check" globally and skip it for unrelated PRs. Instead, musl and zlib opt out of `platformAutomerge` and override `automergeType: "pr"`, which makes Renovate explicitly wait for the build check to report green before merging. Other Renovate PRs are unaffected.

This PR itself touches the script, so the `changes` job and the `build-native-executables` Linux entry will both run on this PR — giving us free end-to-end validation of the new pipeline before merging.

- [x] I've added tests to confirm my change works. <!-- This PR is the test: it touches the script so `build-native-executables` runs against the new variables. -->
- [x] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section. <!-- N/A — infra/CI only, no user-visible changes. -->
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).