### PR TITLE
Support Apex multiline string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Support Apex multiline string literals (`'''...'''`), preserving their content verbatim ([release notes](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_multiline_string.htm&release=262&type=5)).
 - Fix trailing empty line not printed after ignored nodes in class declaration blocks ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1892)).
 - Fix standalone comments before SOQL `WITH SECURITY_ENFORCED` / `WITH USER_MODE` / `WITH SYSTEM_MODE` clauses migrating between `WITH` and the identifier across format passes.
 - Fix trailing comments on the last field of a SOSL `RETURNING X(...)` clause migrating outside the closing paren across format passes.

--- a/packages/prettier-plugin-apex/tests/multiline_string/MultilineString.cls
+++ b/packages/prettier-plugin-apex/tests/multiline_string/MultilineString.cls
@@ -1,0 +1,78 @@
+class MultilineString {
+  void basicPoem() {
+    String myPoem = '''
+       Multiline strings are here, hooray!
+       You can start using them today.
+       Triple quote, then start a new line,
+       For example this will work fine,
+       Poetry is not my forte!''';
+  }
+
+  void closerOnOwnLine() {
+    String message = '''
+      Dear customer,
+      Your order has shipped.
+      Thank you for your business.
+    ''';
+  }
+
+  void singleContentLine() {
+    String singleLineWithLeadingNewline = '''
+hello''';
+  }
+
+  void escapesAndEmbeddedQuotes() {
+    String withEscapes = '''
+      line one\nstill line one (literal backslash-n)
+      tab\there
+      backslash: \\
+    ''';
+    String withEmbeddedQuotes = '''
+      It's a beautiful day
+      She said ''hi'' and waved
+    ''';
+  }
+
+  void stringTemplate() {
+    String message = '''
+      Hello ${firstName},
+      Your order was dispatched on ${dispatchDate}
+    '''.template(new Map<String, Object>{
+      'firstName' => 'Paul',
+      'dispatchDate' => Date.today()
+    });
+  }
+
+  void asMethodArgument() {
+    System.debug('''
+      passed straight into a call
+    ''');
+  }
+
+  void inReturn() {
+    return '''
+      returned directly
+    '''.template(new Map<String, Object>{ 'x' => 1 });
+  }
+
+  void inExpressions() {
+    String concatenated = '''
+      head
+    ''' + ' tail';
+    String ternary = cond
+      ? '''
+        when true
+      '''
+      : 'when false';
+  }
+
+  void withComments() {
+    // leading line comment
+    String a = '''
+      content with a // not-a-comment inside
+    '''; // trailing line comment
+    String b = /* block before */ '''
+      more content
+    ''';
+  }
+}

--- a/packages/prettier-plugin-apex/tests/multiline_string/__snapshots__/FormattedMultilineString1.cls
+++ b/packages/prettier-plugin-apex/tests/multiline_string/__snapshots__/FormattedMultilineString1.cls
@@ -1,0 +1,80 @@
+class MultilineString {
+  void basicPoem() {
+    String myPoem = '''
+       Multiline strings are here, hooray!
+       You can start using them today.
+       Triple quote, then start a new line,
+       For example this will work fine,
+       Poetry is not my forte!''';
+  }
+
+  void closerOnOwnLine() {
+    String message = '''
+      Dear customer,
+      Your order has shipped.
+      Thank you for your business.
+    ''';
+  }
+
+  void singleContentLine() {
+    String singleLineWithLeadingNewline = '''
+hello''';
+  }
+
+  void escapesAndEmbeddedQuotes() {
+    String withEscapes = '''
+      line one\nstill line one (literal backslash-n)
+      tab\there
+      backslash: \\
+    ''';
+    String withEmbeddedQuotes = '''
+      It's a beautiful day
+      She said ''hi'' and waved
+    ''';
+  }
+
+  void stringTemplate() {
+    String message = '''
+      Hello ${firstName},
+      Your order was dispatched on ${dispatchDate}
+    '''
+      .template(
+        new Map<String, Object>{
+          'firstName' => 'Paul',
+          'dispatchDate' => Date.today()
+        }
+      );
+  }
+
+  void asMethodArgument() {
+    System.debug('''
+      passed straight into a call
+    ''');
+  }
+
+  void inReturn() {
+    return '''
+      returned directly
+    '''
+      .template(new Map<String, Object>{ 'x' => 1 });
+  }
+
+  void inExpressions() {
+    String concatenated = '''
+      head
+    ''' + ' tail';
+    String ternary = cond ? '''
+        when true
+      ''' : 'when false';
+  }
+
+  void withComments() {
+    // leading line comment
+    String a = '''
+      content with a // not-a-comment inside
+    '''; // trailing line comment
+    String b = /* block before */ '''
+      more content
+    ''';
+  }
+}

--- a/packages/prettier-plugin-apex/tests/multiline_string/jsfmt.spec.ts
+++ b/packages/prettier-plugin-apex/tests/multiline_string/jsfmt.spec.ts
@@ -1,0 +1,3 @@
+import { fileURLToPath } from "url";
+
+runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);


### PR DESCRIPTION
## Context

[Apex release 262 (Spring '26)](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_multiline_string.htm&release=262&type=5) adds triple-quoted multiline string literals (`'''…'''`) and a `.template(Map<String, Object>)` method on them for interpolation:

```apex
String myPoem = '''
   Multiline strings are here, hooray!
   You can start using them today.''';
```

This was blocked on a jorje refresh; the jar bundled as of #2402 now parses the syntax, so this lands the actual support.

## What changed

- **No printer change needed.** jorje parses a multiline string as a plain `STRING` `LiteralExpr` whose `loc` spans the entire `'''…'''`. The existing literal path already slices the original source verbatim, so the content — including significant whitespace, `${...}` placeholders, and escape sequences — is preserved exactly. Idempotent and AST_COMPARE clean.
- Reworked the fixture into a snapshot test covering the poem example, closer-on-its-own-line, leading-newline content, escapes/embedded quotes, the `.template(Map)` call, use as a method argument and in `return`, and comments around the literal.
- Dropped the empty (`''''''`) and single-line (`'''one line'''`) variants from the original probe — jorje requires a newline immediately after the opening `'''`, so neither is valid Apex.

## Formatting note

`.template(...)` on a long argument currently breaks as a standard member chain (the call drops to its own indented line). Keeping it glued to the closing `'''` is left for a later whitespace-trimming pass.

## Test plan

- [x] `test:parser --configuration built-in` (full suite, 94 tests)
- [x] `AST_COMPARE=true …` on the new fixture
- [x] lint
