### PR TITLE
Add fixtures for SOQL/SOSL WITH USER_MODE and WITH SYSTEM_MODE

### DIFF
--- a/packages/prettier-plugin-apex/tests/soql_user_mode/SOQLUserMode.cls
+++ b/packages/prettier-plugin-apex/tests/soql_user_mode/SOQLUserMode.cls
@@ -1,0 +1,78 @@
+class SOQLUserMode {
+  void basicUserMode() {
+    Account[] users = [SELECT Id FROM Account WITH USER_MODE];
+    Account[] systems = [SELECT Id FROM Account WITH SYSTEM_MODE];
+  }
+
+  void caseVariants() {
+    Account[] lower = [SELECT Id FROM Account with user_mode];
+    Account[] mixed = [SELECT Id FROM Account With User_Mode];
+    Account[] sysLower = [SELECT Id FROM Account with system_mode];
+  }
+
+  void withOtherClauses() {
+    Account[] whereAndUserMode = [SELECT Id FROM Account WHERE Name = 'Acme' WITH USER_MODE];
+    Account[] userModeBeforeWhere = [SELECT Id FROM Account WHERE Name = 'Acme' WITH USER_MODE ORDER BY Name];
+    Account[] userModeWithGroup = [SELECT Industry, COUNT(Id) FROM Account WITH USER_MODE GROUP BY Industry];
+    Account[] userModeAllRows = [SELECT Id FROM Account WHERE IsDeleted = TRUE WITH USER_MODE ALL ROWS];
+    Account[] userModeForUpdate = [SELECT Id FROM Account WHERE Name LIKE 'A%' WITH USER_MODE LIMIT 50 FOR UPDATE];
+  }
+
+  void combinedWithIdentifiers() {
+    Account[] userModeRandom = [SELECT Id FROM Account WITH USER_MODE WITH RANDOM_IDENTIFIER];
+    Account[] randomThenUserMode = [SELECT Id FROM Account WITH RANDOM_IDENTIFIER WITH USER_MODE];
+  }
+
+  void longLineForcesWrapping() {
+    Account[] longQuery = [SELECT Id, Name, BillingCity, BillingState, BillingCountry, ShippingCity, ShippingState, AnnualRevenue, NumberOfEmployees FROM Account WHERE Name LIKE 'Acme%' AND AnnualRevenue > 1000000 AND NumberOfEmployees > 100 WITH USER_MODE ORDER BY AnnualRevenue DESC, Name ASC NULLS LAST LIMIT 200];
+  }
+
+  void multilineBodyTightenable() {
+    Account[] verbose = [
+      SELECT Id
+      FROM Account
+      WITH USER_MODE
+    ];
+    Account[] verboseSystem = [
+      SELECT Id, Name
+      FROM Account
+      WHERE Name = 'Acme'
+      WITH SYSTEM_MODE
+      ORDER BY Name
+      LIMIT 10
+    ];
+  }
+
+  void embeddedComments() {
+    Account[] trailingComment = [
+      SELECT Id
+      FROM Account
+      WITH USER_MODE // <-- intentional
+    ];
+    Account[] commentsEverywhere = [
+      // header comment
+      SELECT Id, // trailing on column
+        Name
+      FROM Account // trailing on table
+      WHERE Name = 'Acme' // trailing on predicate
+      WITH USER_MODE // trailing on mode
+      LIMIT 1 // trailing on limit
+    ];
+  }
+
+  void subqueriesAndUserMode() {
+    Account[] subquery = [
+      SELECT Id, (SELECT Id FROM Contacts LIMIT 5)
+      FROM Account
+      WHERE Id IN (SELECT AccountId FROM Opportunity WHERE Amount > 10000)
+      WITH USER_MODE
+    ];
+  }
+
+  void weirdSpacing() {
+    Account[] extraSpaces = [SELECT Id FROM Account    WITH    USER_MODE];
+    Account[] mixedNewlines = [SELECT Id FROM Account
+      WITH USER_MODE
+      LIMIT 1];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_user_mode/__snapshots__/FormattedSOQLUserMode1.cls
+++ b/packages/prettier-plugin-apex/tests/soql_user_mode/__snapshots__/FormattedSOQLUserMode1.cls
@@ -1,0 +1,138 @@
+class SOQLUserMode {
+  void basicUserMode() {
+    Account[] users = [SELECT Id FROM Account WITH USER_MODE];
+    Account[] systems = [SELECT Id FROM Account WITH SYSTEM_MODE];
+  }
+
+  void caseVariants() {
+    Account[] lower = [SELECT Id FROM Account WITH user_mode];
+    Account[] mixed = [SELECT Id FROM Account WITH User_Mode];
+    Account[] sysLower = [SELECT Id FROM Account WITH system_mode];
+  }
+
+  void withOtherClauses() {
+    Account[] whereAndUserMode = [
+      SELECT Id
+      FROM Account
+      WHERE Name = 'Acme'
+      WITH USER_MODE
+    ];
+    Account[] userModeBeforeWhere = [
+      SELECT Id
+      FROM Account
+      WHERE Name = 'Acme'
+      WITH USER_MODE
+      ORDER BY Name
+    ];
+    Account[] userModeWithGroup = [
+      SELECT Industry, COUNT(Id)
+      FROM Account
+      WITH USER_MODE
+      GROUP BY Industry
+    ];
+    Account[] userModeAllRows = [
+      SELECT Id
+      FROM Account
+      WHERE IsDeleted = TRUE
+      WITH USER_MODE
+      ALL ROWS
+    ];
+    Account[] userModeForUpdate = [
+      SELECT Id
+      FROM Account
+      WHERE Name LIKE 'A%'
+      WITH USER_MODE
+      LIMIT 50
+      FOR UPDATE
+    ];
+  }
+
+  void combinedWithIdentifiers() {
+    Account[] userModeRandom = [
+      SELECT Id
+      FROM Account
+      WITH USER_MODE WITH RANDOM_IDENTIFIER
+    ];
+    Account[] randomThenUserMode = [
+      SELECT Id
+      FROM Account
+      WITH RANDOM_IDENTIFIER WITH USER_MODE
+    ];
+  }
+
+  void longLineForcesWrapping() {
+    Account[] longQuery = [
+      SELECT
+        Id,
+        Name,
+        BillingCity,
+        BillingState,
+        BillingCountry,
+        ShippingCity,
+        ShippingState,
+        AnnualRevenue,
+        NumberOfEmployees
+      FROM Account
+      WHERE
+        Name LIKE 'Acme%'
+        AND AnnualRevenue > 1000000
+        AND NumberOfEmployees > 100
+      WITH USER_MODE
+      ORDER BY AnnualRevenue DESC, Name ASC NULLS LAST
+      LIMIT 200
+    ];
+  }
+
+  void multilineBodyTightenable() {
+    Account[] verbose = [
+      SELECT Id
+      FROM Account
+      WITH USER_MODE
+    ];
+    Account[] verboseSystem = [
+      SELECT Id, Name
+      FROM Account
+      WHERE Name = 'Acme'
+      WITH SYSTEM_MODE
+      ORDER BY Name
+      LIMIT 10
+    ];
+  }
+
+  void embeddedComments() {
+    Account[] trailingComment = [
+      SELECT Id
+      FROM Account
+      WITH USER_MODE // <-- intentional
+    ];
+    Account[] commentsEverywhere = [
+      // header comment
+      SELECT
+        Id, // trailing on column
+        Name
+      FROM Account // trailing on table
+      WHERE Name = 'Acme' // trailing on predicate
+      WITH USER_MODE // trailing on mode
+      LIMIT 1 // trailing on limit
+    ];
+  }
+
+  void subqueriesAndUserMode() {
+    Account[] subquery = [
+      SELECT Id, (SELECT Id FROM Contacts LIMIT 5)
+      FROM Account
+      WHERE Id IN (SELECT AccountId FROM Opportunity WHERE Amount > 10000)
+      WITH USER_MODE
+    ];
+  }
+
+  void weirdSpacing() {
+    Account[] extraSpaces = [SELECT Id FROM Account WITH USER_MODE];
+    Account[] mixedNewlines = [
+      SELECT Id
+      FROM Account
+      WITH USER_MODE
+      LIMIT 1
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_user_mode/jsfmt.spec.ts
+++ b/packages/prettier-plugin-apex/tests/soql_user_mode/jsfmt.spec.ts
@@ -1,0 +1,3 @@
+import { fileURLToPath } from "url";
+
+runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);

--- a/packages/prettier-plugin-apex/tests/sosl_user_mode/SOSLUserMode.cls
+++ b/packages/prettier-plugin-apex/tests/sosl_user_mode/SOSLUserMode.cls
@@ -1,0 +1,75 @@
+class SOSLUserMode {
+  void basicUserMode() {
+    List<List<SObject>> users = [FIND 'Acme' RETURNING Account WITH USER_MODE];
+    List<List<SObject>> systems = [FIND 'Acme' RETURNING Account WITH SYSTEM_MODE];
+  }
+
+  void caseVariants() {
+    List<List<SObject>> lower = [FIND 'Acme' RETURNING Account with user_mode];
+    List<List<SObject>> mixed = [FIND 'Acme' RETURNING Account With User_Mode];
+    List<List<SObject>> sysLower = [FIND 'Acme' RETURNING Account with system_mode];
+  }
+
+  void withInClause() {
+    List<List<SObject>> inAllFields = [FIND 'Acme' IN ALL FIELDS RETURNING Account(Name) WITH USER_MODE];
+    List<List<SObject>> inEmailFields = [FIND 'support@example.com' IN EMAIL FIELDS RETURNING Contact(Email, Name) WITH USER_MODE];
+    List<List<SObject>> inNameFields = [FIND 'Acme' IN NAME FIELDS RETURNING Account(Name) WITH SYSTEM_MODE];
+  }
+
+  void combinedWithOtherClauses() {
+    List<List<SObject>> withDivision = [FIND 'Acme' RETURNING Account(Name) WITH Division = 'Global' WITH USER_MODE];
+    List<List<SObject>> withHighlight = [FIND 'Acme' RETURNING Account(Name) WITH HIGHLIGHT WITH USER_MODE];
+    List<List<SObject>> withSnippet = [FIND 'Acme' RETURNING Account(Name) WITH SNIPPET (target_length=120) WITH USER_MODE];
+    List<List<SObject>> withSpellCorrection = [FIND 'Acme' RETURNING Account(Name) WITH SPELL_CORRECTION = true WITH USER_MODE];
+  }
+
+  void longLineForcesWrapping() {
+    List<List<SObject>> longQuery = [FIND 'Acme Corporation Headquarters' IN ALL FIELDS RETURNING Account(Id, Name, BillingCity, BillingState, BillingCountry WHERE Name LIKE 'Acme%' ORDER BY Name ASC LIMIT 100), Contact(Id, FirstName, LastName, Email LIMIT 50), Opportunity(Id, Name, Amount WHERE Amount > 1000 LIMIT 25) WITH USER_MODE];
+  }
+
+  void multilineBodyTightenable() {
+    List<List<SObject>> verbose = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH USER_MODE
+    ];
+    List<List<SObject>> verboseSystem = [
+      FIND 'Acme'
+      IN ALL FIELDS
+      RETURNING Account(Name)
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  void embeddedComments() {
+    List<List<SObject>> trailingComment = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH USER_MODE // intentional
+    ];
+    List<List<SObject>> commentsEverywhere = [
+      // header
+      FIND 'Acme' // trailing on FIND
+      IN ALL FIELDS // trailing on IN clause
+      RETURNING Account(Name)
+      WITH USER_MODE // trailing on mode
+    ];
+  }
+
+  void multipleReturningWithUserMode() {
+    List<List<SObject>> multi = [
+      FIND 'Acme'
+      RETURNING Account(Name, Industry),
+        Contact(FirstName, LastName),
+        Opportunity(Name, Amount)
+      WITH USER_MODE
+    ];
+  }
+
+  void weirdSpacing() {
+    List<List<SObject>> extraSpaces = [FIND 'Acme' RETURNING Account    WITH    USER_MODE];
+    List<List<SObject>> mixedNewlines = [FIND 'Acme'
+      RETURNING Account
+      WITH USER_MODE];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/sosl_user_mode/__snapshots__/FormattedSOSLUserMode1.cls
+++ b/packages/prettier-plugin-apex/tests/sosl_user_mode/__snapshots__/FormattedSOSLUserMode1.cls
@@ -1,0 +1,141 @@
+class SOSLUserMode {
+  void basicUserMode() {
+    List<List<SObject>> users = [FIND 'Acme' RETURNING Account WITH USER_MODE];
+    List<List<SObject>> systems = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  void caseVariants() {
+    List<List<SObject>> lower = [FIND 'Acme' RETURNING Account WITH user_mode];
+    List<List<SObject>> mixed = [FIND 'Acme' RETURNING Account WITH User_Mode];
+    List<List<SObject>> sysLower = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH system_mode
+    ];
+  }
+
+  void withInClause() {
+    List<List<SObject>> inAllFields = [
+      FIND 'Acme'
+      IN ALL FIELDS
+      RETURNING Account(Name)
+      WITH USER_MODE
+    ];
+    List<List<SObject>> inEmailFields = [
+      FIND 'support@example.com'
+      IN EMAIL FIELDS
+      RETURNING Contact(Email, Name)
+      WITH USER_MODE
+    ];
+    List<List<SObject>> inNameFields = [
+      FIND 'Acme'
+      IN NAME FIELDS
+      RETURNING Account(Name)
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  void combinedWithOtherClauses() {
+    List<List<SObject>> withDivision = [
+      FIND 'Acme'
+      RETURNING Account(Name)
+      WITH DIVISION = 'Global'
+      WITH USER_MODE
+    ];
+    List<List<SObject>> withHighlight = [
+      FIND 'Acme'
+      RETURNING Account(Name)
+      WITH HIGHLIGHT
+      WITH USER_MODE
+    ];
+    List<List<SObject>> withSnippet = [
+      FIND 'Acme'
+      RETURNING Account(Name)
+      WITH SNIPPET(target_length = 120)
+      WITH USER_MODE
+    ];
+    List<List<SObject>> withSpellCorrection = [
+      FIND 'Acme'
+      RETURNING Account(Name)
+      WITH SPELL_CORRECTION = true
+      WITH USER_MODE
+    ];
+  }
+
+  void longLineForcesWrapping() {
+    List<List<SObject>> longQuery = [
+      FIND 'Acme Corporation Headquarters'
+      IN ALL FIELDS
+      RETURNING
+        Account(
+          Id,
+          Name,
+          BillingCity,
+          BillingState,
+          BillingCountry
+          WHERE Name LIKE 'Acme%'
+          ORDER BY Name ASC
+          LIMIT 100),
+        Contact(Id, FirstName, LastName, Email LIMIT 50),
+        Opportunity(Id, Name, Amount WHERE Amount > 1000 LIMIT 25)
+      WITH USER_MODE
+    ];
+  }
+
+  void multilineBodyTightenable() {
+    List<List<SObject>> verbose = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH USER_MODE
+    ];
+    List<List<SObject>> verboseSystem = [
+      FIND 'Acme'
+      IN ALL FIELDS
+      RETURNING Account(Name)
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  void embeddedComments() {
+    List<List<SObject>> trailingComment = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH USER_MODE // intentional
+    ];
+    List<List<SObject>> commentsEverywhere = [
+      // header
+      FIND 'Acme' // trailing on FIND
+      IN ALL FIELDS // trailing on IN clause
+      RETURNING Account(Name)
+      WITH USER_MODE // trailing on mode
+    ];
+  }
+
+  void multipleReturningWithUserMode() {
+    List<List<SObject>> multi = [
+      FIND 'Acme'
+      RETURNING
+        Account(Name, Industry),
+        Contact(FirstName, LastName),
+        Opportunity(Name, Amount)
+      WITH USER_MODE
+    ];
+  }
+
+  void weirdSpacing() {
+    List<List<SObject>> extraSpaces = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH USER_MODE
+    ];
+    List<List<SObject>> mixedNewlines = [
+      FIND 'Acme'
+      RETURNING Account
+      WITH USER_MODE
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/sosl_user_mode/jsfmt.spec.ts
+++ b/packages/prettier-plugin-apex/tests/sosl_user_mode/jsfmt.spec.ts
@@ -1,0 +1,3 @@
+import { fileURLToPath } from "url";
+
+runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);


### PR DESCRIPTION
## Context

User-mode database operations have shipped in three waves:

| Release | Construct | Status before this PR |
|---|---|---|
| Summer '22 | DML `as user` / `as system` | Covered by `tests/dml/DmlClass.cls` |
| Spring '23 | SOQL `WITH USER_MODE` / `WITH SYSTEM_MODE` | **No fixture** |
| Summer '23 | SOSL `WITH USER_MODE` / `WITH SYSTEM_MODE` | **No fixture** |

The plugin's generic `WITH_IDENTIFIER` printer already round-trips these clauses correctly — they've been silently working for releases. This PR locks the behavior in with snapshot fixtures so any future printer or jorje regression surfaces immediately.

## Curveballs covered

**SOQL (`tests/soql_user_mode/SOQLUserMode.cls`):**
- Case variants: `WITH USER_MODE`, `with user_mode`, `With User_Mode`
- Combined with `WHERE`, `ORDER BY`, `GROUP BY`, `ALL ROWS`, `FOR UPDATE`, `LIMIT`
- Multiple chained WITH clauses: `WITH USER_MODE WITH RANDOM_IDENTIFIER` (and reverse)
- Long lines that force column-per-line wrapping
- Multi-line bodies that should be left as-is (already tight)
- Subqueries combined with `WITH USER_MODE`
- Weird whitespace (extra spaces, mid-query newlines)
- Trailing line comments on every clause

**SOSL (`tests/sosl_user_mode/SOSLUserMode.cls`):**
- Case variants
- `IN ALL/EMAIL/NAME FIELDS` combined with USER_MODE
- Combinations with other WITH clauses: `WITH DIVISION`, `WITH HIGHLIGHT`, `WITH SNIPPET(target_length=120)`, `WITH SPELL_CORRECTION = true`
- Long lines (multi-RETURNING with WHERE/ORDER BY/LIMIT per-target)
- Multi-RETURNING
- Trailing line comments

## Known limitation — not addressed here

Standalone preceding line/block comments **immediately before** `WITH USER_MODE` (e.g. `// preceding\nWITH USER_MODE`) trigger a pre-existing comment-attachment idempotency bug: the comment migrates between `WITH` and the identifier across format passes, so `AST_COMPARE` / `Stable format` fails. Reproduced on `WITH SECURITY_ENFORCED` with the same pattern. Out of scope for a fixture-only PR — worth a follow-up issue against the printer's comment-attachment logic.

## What's *not* in this PR

- **`FORMULA(expr)` in SOQL WHERE** (Summer '26 pilot). Probed during this work — the bundled jorje (refreshed 2026-04-06) does **not** parse arithmetic inside `FORMULA(...)` yet, so a green fixture isn't possible. Same blocker pattern as #2388 (Apex multiline strings).

## Test plan

- [x] `pnpm nx run prettier-plugin-apex:lint`
- [x] `pnpm vitest run -u tests/soql_user_mode tests/sosl_user_mode` — both green
- [x] Full suite: `pnpm vitest run` — 55 test files / 91 tests passed
- [x] `AST_COMPARE=true pnpm vitest run tests/soql_user_mode tests/sosl_user_mode` — green (6/6 incl. stable-format)
- [ ] CI on the draft PR