### PR TITLE
Support SOQL FORMULA() in WHERE clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Support Apex multiline string literals (`'''...'''`), preserving their content verbatim ([release notes](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_multiline_string.htm&release=262&type=5)).
+- Support the SOQL `FORMULA('...')` function in `WHERE` clauses ([release notes](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_soql_formula_function.htm&release=262&type=5)). The formula expression is printed verbatim from the source.
 - Fix trailing empty line not printed after ignored nodes in class declaration blocks ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1892)).
 - Fix standalone comments before SOQL `WITH SECURITY_ENFORCED` / `WITH USER_MODE` / `WITH SYSTEM_MODE` clauses migrating between `WITH` and the identifier across format passes.
 - Fix trailing comments on the last field of a SOSL `RETURNING X(...)` clause migrating outside the closing paren across format passes.

--- a/packages/prettier-plugin-apex/src/constants.ts
+++ b/packages/prettier-plugin-apex/src/constants.ts
@@ -260,6 +260,10 @@ export const APEX_TYPES = {
     "apex.jorje.data.soql.WhereExpr$WhereDistanceExpr" as const,
   DISTANCE_FUNCTION_EXPRESSION:
     "apex.jorje.data.soql.DistanceFunctionExpr" as const,
+  WHERE_FORMULA_EXPRESSION:
+    "apex.jorje.data.soql.WhereExpr$WhereFormulaExpr" as const,
+  FORMULA_FUNCTION_EXPRESSION:
+    "apex.jorje.data.soql.FormulaFunctionExpr" as const,
   GEOLOCATION_LITERAL:
     "apex.jorje.data.soql.Geolocation$GeolocationLiteral" as const,
   GEOLOCATION_EXPRESSION:

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -459,6 +459,7 @@ const locationGenerationHandler: {
   [APEX_TYPES.WHERE_COMPOUND_EXPRESSION]: handleWhereCompoundExpressionLocation,
   [APEX_TYPES.WHERE_OPERATION_EXPRESSION]:
     handleWhereOperationExpressionLocation,
+  [APEX_TYPES.WHERE_FORMULA_EXPRESSION]: handleWhereOperationExpressionLocation,
   [APEX_TYPES.WHERE_UNARY_EXPRESSION]: handleWhereUnaryExpressionLocation,
   [APEX_TYPES.SELECT_INNER_QUERY]: handleNodeSurroundedByCharacters("(", ")"),
   [APEX_TYPES.ANONYMOUS_BLOCK_UNIT]: handleAnonymousUnitLocation,

--- a/packages/prettier-plugin-apex/src/printer.ts
+++ b/packages/prettier-plugin-apex/src/printer.ts
@@ -2366,6 +2366,33 @@ function handleDistanceFunctionExpression(path: AstPath, print: PrintFn): Doc {
   return groupIndentConcat(parts);
 }
 
+function handleWhereFormulaExpression(path: AstPath, print: PrintFn): Doc {
+  const parts: Doc[] = [];
+  parts.push(path.call(print, "formula"));
+  parts.push(" ");
+  parts.push(path.call(print, "op"));
+  parts.push(" ");
+  parts.push(path.call(print, "expr"));
+  return groupConcat(parts);
+}
+
+function handleFormulaFunctionExpression(
+  path: AstPath,
+  _print: PrintFn,
+  options: prettier.ParserOptions,
+): Doc {
+  // The formula is an opaque string expression that jorje does not parse, so
+  // we print its body verbatim from the source. The node location spans the
+  // whole `FORMULA('...')` call. We uppercase the `FORMULA` keyword to stay
+  // consistent with the other SOQL functions (e.g. DISTANCE, GEOLOCATION).
+  const node = path.getNode();
+  const source = options.originalText.slice(
+    node.loc.startIndex,
+    node.loc.endIndex,
+  );
+  return source.replace(/^formula/i, "FORMULA");
+}
+
 function handleGeolocationLiteral(path: AstPath, print: PrintFn): Doc {
   const parts: Doc[] = [];
   const childParts: Doc[] = [];
@@ -3175,6 +3202,8 @@ const nodeHandler: { [key: string]: ChildNodeHandler | SingleNodeHandler } = {
   [APEX_TYPES.SELECT_DISTANCE_EXPRESSION]: handleSelectDistanceExpression,
   [APEX_TYPES.WHERE_DISTANCE_EXPRESSION]: handleWhereDistanceExpression,
   [APEX_TYPES.DISTANCE_FUNCTION_EXPRESSION]: handleDistanceFunctionExpression,
+  [APEX_TYPES.WHERE_FORMULA_EXPRESSION]: handleWhereFormulaExpression,
+  [APEX_TYPES.FORMULA_FUNCTION_EXPRESSION]: handleFormulaFunctionExpression,
   [APEX_TYPES.GEOLOCATION_LITERAL]: handleGeolocationLiteral,
   [APEX_TYPES.GEOLOCATION_EXPRESSION]: handleGeolocationExpression,
   [APEX_TYPES.NUMBER_LITERAL]: handleNumberLiteral,

--- a/packages/prettier-plugin-apex/tests/soql_formula/FormulaProbe.cls
+++ b/packages/prettier-plugin-apex/tests/soql_formula/FormulaProbe.cls
@@ -1,0 +1,73 @@
+class FormulaProbe {
+  void basicFormula() {
+    Opportunity[] opps = [
+      SELECT Id FROM Opportunity WHERE FORMULA('Amount * 0.1') > 500
+    ];
+  }
+
+  void formulaWithFieldReferences() {
+    Opportunity[] opps = [
+      SELECT Id, Name
+      FROM Opportunity
+      WHERE FORMULA('Amount - Discount__c') > 1000
+      AND FORMULA('Account.AnnualRevenue / 12') >= 10000
+    ];
+  }
+
+  void formulaComparedToBindVariable() {
+    Decimal threshold = 500;
+    Opportunity[] opps = [
+      SELECT Id
+      FROM Opportunity
+      WHERE FORMULA('Amount * 0.1') > :threshold
+    ];
+  }
+
+  void formulaCombinedWithLogicalOperators() {
+    Account[] accounts = [
+      SELECT Id, Name
+      FROM Account
+      WHERE (FORMULA('NumberOfEmployees * 1000') > 50000 OR Type = 'Prospect')
+      AND FORMULA('AnnualRevenue - Expenses__c') > 0
+    ];
+  }
+
+  void formulaComparedToString() {
+    Account[] accounts = [
+      SELECT Id FROM Account WHERE FORMULA('FirstName & LastName') = 'AcmeCorp'
+    ];
+  }
+
+  void emptyFormula() {
+    Account[] accounts = [
+      SELECT Id FROM Account WHERE FORMULA('') > 0
+    ];
+  }
+
+  void longFormulaLine() {
+    Opportunity[] opps = [
+      SELECT Id, Name, Amount, ExpectedRevenue, CloseDate, StageName, AccountId, OwnerId
+      FROM Opportunity
+      WHERE FORMULA('Amount * 0.15 + ExpectedRevenue * 0.05 - Discount__c + Adjustment__c') > 25000
+    ];
+  }
+
+  void formulaKeywordCasing() {
+    Account[] lower = [
+      SELECT Id FROM Account WHERE formula('Amount * 0.1') > 500
+    ];
+    Account[] mixed = [
+      SELECT Id FROM Account WHERE Formula('Amount * 0.1') > 500
+    ];
+  }
+
+  void formulaWithComments() {
+    Opportunity[] opps = [
+      SELECT Id
+      FROM Opportunity
+      // filter on weighted amount
+      WHERE FORMULA('Amount * 0.1') > 500
+      AND /* inline */ FORMULA('ExpectedRevenue - Amount') > 0
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_formula/__snapshots__/FormattedFormulaProbe1.cls
+++ b/packages/prettier-plugin-apex/tests/soql_formula/__snapshots__/FormattedFormulaProbe1.cls
@@ -1,0 +1,92 @@
+class FormulaProbe {
+  void basicFormula() {
+    Opportunity[] opps = [
+      SELECT Id
+      FROM Opportunity
+      WHERE FORMULA('Amount * 0.1') > 500
+    ];
+  }
+
+  void formulaWithFieldReferences() {
+    Opportunity[] opps = [
+      SELECT Id, Name
+      FROM Opportunity
+      WHERE
+        FORMULA('Amount - Discount__c') > 1000
+        AND FORMULA('Account.AnnualRevenue / 12') >= 10000
+    ];
+  }
+
+  void formulaComparedToBindVariable() {
+    Decimal threshold = 500;
+    Opportunity[] opps = [
+      SELECT Id
+      FROM Opportunity
+      WHERE FORMULA('Amount * 0.1') > :threshold
+    ];
+  }
+
+  void formulaCombinedWithLogicalOperators() {
+    Account[] accounts = [
+      SELECT Id, Name
+      FROM Account
+      WHERE
+        (FORMULA('NumberOfEmployees * 1000') > 50000
+        OR Type = 'Prospect')
+        AND FORMULA('AnnualRevenue - Expenses__c') > 0
+    ];
+  }
+
+  void formulaComparedToString() {
+    Account[] accounts = [
+      SELECT Id
+      FROM Account
+      WHERE FORMULA('FirstName & LastName') = 'AcmeCorp'
+    ];
+  }
+
+  void emptyFormula() {
+    Account[] accounts = [SELECT Id FROM Account WHERE FORMULA('') > 0];
+  }
+
+  void longFormulaLine() {
+    Opportunity[] opps = [
+      SELECT
+        Id,
+        Name,
+        Amount,
+        ExpectedRevenue,
+        CloseDate,
+        StageName,
+        AccountId,
+        OwnerId
+      FROM Opportunity
+      WHERE
+        FORMULA('Amount * 0.15 + ExpectedRevenue * 0.05 - Discount__c + Adjustment__c') > 25000
+    ];
+  }
+
+  void formulaKeywordCasing() {
+    Account[] lower = [
+      SELECT Id
+      FROM Account
+      WHERE FORMULA('Amount * 0.1') > 500
+    ];
+    Account[] mixed = [
+      SELECT Id
+      FROM Account
+      WHERE FORMULA('Amount * 0.1') > 500
+    ];
+  }
+
+  void formulaWithComments() {
+    Opportunity[] opps = [
+      SELECT Id
+      FROM Opportunity
+      // filter on weighted amount
+      WHERE
+        FORMULA('Amount * 0.1') > 500 /* inline */
+        AND FORMULA('ExpectedRevenue - Amount') > 0
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_formula/jsfmt.spec.ts
+++ b/packages/prettier-plugin-apex/tests/soql_formula/jsfmt.spec.ts
@@ -1,0 +1,3 @@
+import { fileURLToPath } from "url";
+
+runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);


### PR DESCRIPTION
## Context

[Apex release 262](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_soql_formula_function.htm&release=262&type=5) adds the SOQL `FORMULA('expression')` function for filtering in `WHERE` clauses (pilot). The formula is passed as a **single-quoted string** that the platform compiles per row:

```apex
[SELECT Id FROM Opportunity WHERE FORMULA('Amount * 0.1') > 500]
```

The original fixture in this PR used *unquoted* arithmetic (`FORMULA(Amount * 0.1)`), which was never valid Apex — that's why it didn't parse, not a jorje gap. The jar from #2402 parses the quoted form, so this lands actual support.

## What changed

- jorje parses it into `WhereExpr$WhereFormulaExpr` (`formula` / `op` / `expr`), wrapping a `FormulaFunctionExpr`. This mirrors the existing `DISTANCE()` shape, so `handleWhereFormulaExpression` is a near-copy of `handleWhereDistanceExpression`.
- The formula body is an opaque string jorje doesn't parse, so it's printed **verbatim from source** — `FormulaFunctionExpr`'s `loc` spans the whole `FORMULA('...')` call, preserving the inner expression exactly. The `FORMULA` keyword itself is uppercased to match the other SOQL functions (`DISTANCE`, `GEOLOCATION`).
- `WhereFormulaExpr` reuses the `WhereOpExpr` location handler so a parenthesised formula attaches comments correctly and survives `// prettier-ignore`.
- Reworked the fixture with the correct quoted syntax and dropped the cases jorje rejects: nested `FORMULA(FORMULA(...))`, FORMULA on both sides of a comparison, and the standalone boolean form. Replaced "both sides" with a bind-variable comparison, and added empty-string, string-comparison, keyword-casing, and comment edge cases.

## Behavior notes

- An over-long `FORMULA('…') > N` keeps the FORMULA atomic (can't break inside the string) and wraps at the surrounding `AND`/`OR`, same as any other where-expression.
- `''`-escaped quotes inside the formula string are rejected by jorje, so a formula can't contain a literal single quote today. Not handled here because it isn't valid Apex.

## Test plan

- [x] `test:parser --configuration built-in` (full suite, 94 tests)
- [x] `AST_COMPARE=true …` (full suite, 270 checks)
- [x] `// prettier-ignore` round-trips a parenthesised formula verbatim
- [x] lint
