### PR TITLE
Stabilize comments before SOQL WITH identifier clauses

### DIFF
--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -241,12 +241,12 @@ function handleWithIdentifierLocation(
   // Prettier sees them as preceding the inner identifier, attaches them as
   // a leading comment, and the printer emits them between `WITH` and the
   // identifier on subsequent format passes. We perform a case-insensitive
-  // backwards scan for `WITH` to anchor the start of the node.
+  // backwards scan for `WITH` to anchor the start of the node. A
+  // `WithIdentifier` AST node is only ever produced when the source contains
+  // a `WITH` keyword before the identifier, so `lastIndexOf` will always
+  // find a match here.
   const upToStart = sourceCode.slice(0, location.startIndex).toLowerCase();
   const withIndex = upToStart.lastIndexOf("with");
-  if (withIndex === -1) {
-    return location;
-  }
   return {
     startIndex: withIndex,
     endIndex: location.endIndex,

--- a/packages/prettier-plugin-apex/src/parser.ts
+++ b/packages/prettier-plugin-apex/src/parser.ts
@@ -230,6 +230,29 @@ function handleAnnotationLocation(
   );
 }
 
+function handleWithIdentifierLocation(
+  location: MinimalLocation,
+  sourceCode: string,
+): MinimalLocation {
+  // jorje gives us the location of the inner identifier only (e.g.
+  // `SECURITY_ENFORCED`), not the `WITH` keyword in front of it. Without
+  // extending the start back to cover `WITH`, comments that sit between the
+  // previous clause and the `WITH` keyword have nowhere to land:
+  // Prettier sees them as preceding the inner identifier, attaches them as
+  // a leading comment, and the printer emits them between `WITH` and the
+  // identifier on subsequent format passes. We perform a case-insensitive
+  // backwards scan for `WITH` to anchor the start of the node.
+  const upToStart = sourceCode.slice(0, location.startIndex).toLowerCase();
+  const withIndex = upToStart.lastIndexOf("with");
+  if (withIndex === -1) {
+    return location;
+  }
+  return {
+    startIndex: withIndex,
+    endIndex: location.endIndex,
+  };
+}
+
 function handleLimitValueLocation(
   location: MinimalLocation,
   sourceCode: string,
@@ -452,6 +475,7 @@ const locationGenerationHandler: {
   [APEX_TYPES.ANNOTATION]: handleAnnotationLocation,
   [APEX_TYPES.METHOD_DECLARATION]: handleMethodDeclarationLocation,
   [APEX_TYPES.LIMIT_VALUE]: handleLimitValueLocation,
+  [APEX_TYPES.WITH_IDENTIFIER]: handleWithIdentifierLocation,
 };
 
 type AnyNode = any;

--- a/packages/prettier-plugin-apex/tests/soql_with_comment/SOQLWithComment.cls
+++ b/packages/prettier-plugin-apex/tests/soql_with_comment/SOQLWithComment.cls
@@ -1,0 +1,74 @@
+class SOQLWithComment {
+  public void securityEnforcedLineComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH SECURITY_ENFORCED
+    ];
+  }
+
+  public void securityEnforcedBlockComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      /* preceding block comment */
+      WITH SECURITY_ENFORCED
+    ];
+  }
+
+  public void userModeLineComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH USER_MODE
+    ];
+  }
+
+  public void userModeBlockComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      /* preceding block comment */
+      WITH USER_MODE
+    ];
+  }
+
+  public void systemModeLineComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  public void systemModeBlockComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      /* preceding block comment */
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  public void withDivisionValue() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH DIVISION = 'Global'
+    ];
+  }
+
+  public void afterWhereClause() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      WHERE Name = 'Hello'
+      // preceding line comment
+      WITH SECURITY_ENFORCED
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_with_comment/__snapshots__/FormattedSOQLWithComment1.cls
+++ b/packages/prettier-plugin-apex/tests/soql_with_comment/__snapshots__/FormattedSOQLWithComment1.cls
@@ -1,0 +1,74 @@
+class SOQLWithComment {
+  public void securityEnforcedLineComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH SECURITY_ENFORCED
+    ];
+  }
+
+  public void securityEnforcedBlockComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      /* preceding block comment */
+      WITH SECURITY_ENFORCED
+    ];
+  }
+
+  public void userModeLineComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH USER_MODE
+    ];
+  }
+
+  public void userModeBlockComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      /* preceding block comment */
+      WITH USER_MODE
+    ];
+  }
+
+  public void systemModeLineComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  public void systemModeBlockComment() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      /* preceding block comment */
+      WITH SYSTEM_MODE
+    ];
+  }
+
+  public void withDivisionValue() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      // preceding line comment
+      WITH DIVISION = 'Global'
+    ];
+  }
+
+  public void afterWhereClause() {
+    Account[] a = [
+      SELECT Id, Name
+      FROM Account
+      WHERE Name = 'Hello'
+      // preceding line comment
+      WITH SECURITY_ENFORCED
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_with_comment/jsfmt.spec.ts
+++ b/packages/prettier-plugin-apex/tests/soql_with_comment/jsfmt.spec.ts
@@ -1,0 +1,3 @@
+import { fileURLToPath } from "url";
+
+runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);


### PR DESCRIPTION
## The bug

A standalone comment immediately before `WITH SECURITY_ENFORCED` / `WITH USER_MODE` / `WITH SYSTEM_MODE` migrates across format passes:

Input:
```apex
Account[] x = [
  SELECT Id, Name
  FROM Account
  // preceding comment
  WITH SECURITY_ENFORCED
];
```

After one format pass:
```apex
Account[] x = [
  SELECT Id, Name
  FROM Account
  WITH // preceding comment
  SECURITY_ENFORCED
];
```

The comment hops again on the next pass, so `AST_COMPARE=true` fails the stable-format check.

## Root cause

jorje gives `WithIdentifier` nodes (the AST node behind `WITH SECURITY_ENFORCED` and friends) a location that covers only the inner `Identifier`, not the `WITH` keyword. The standalone comment between the previous clause and `WITH` has no node it belongs inside, so Prettier attaches it as a leading comment on the inner `Identifier`. The printer for `WITH_IDENTIFIER` emits `["WITH", " ", identifier]`, which puts the leading comment of the identifier between `WITH` and the keyword.

## Fix

Register a location handler for `WITH_IDENTIFIER` that walks back from jorje's `startIndex` to find the `WITH` keyword. The node now spans the full clause, the comment lands as a leading comment on `WithIdentifier`, and the printer emits it before `WITH`. SOQL is case-insensitive so the scan is too.

## Test plan

- New fixture under `tests/soql_with_comment/` covers preceding line and block comments for `WITH SECURITY_ENFORCED`, `WITH USER_MODE`, `WITH SYSTEM_MODE`, the `WithValue` style `WITH DIVISION = 'x'`, and a `WHERE ... // comment WITH ...` arrangement.
- `AST_COMPARE=true pnpm vitest run` passes across the full suite (258 tests).
- `pnpm nx run prettier-plugin-apex:lint` clean (no new warnings).

## Out of scope

A related SOSL bug -- a trailing comment after the last field in `RETURNING X(..., col // comment)` ends up outside the closing paren and is unstable -- is still present. It's a different root cause (`ReturningExpression`'s location doesn't cover the parens) and naively extending that loc breaks unrelated comment placements. Left for a follow-up.