### PR TITLE
Stabilize trailing comments inside SOSL RETURNING parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix trailing empty line not printed after ignored nodes in class declaration blocks ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1892)).
+- Fix trailing comments on the last field of a SOSL `RETURNING X(...)` clause migrating outside the closing paren across format passes.
 
 ## Dependency Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fix trailing empty line not printed after ignored nodes in class declaration blocks ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1892)).
+- Fix standalone comments before SOQL `WITH SECURITY_ENFORCED` / `WITH USER_MODE` / `WITH SYSTEM_MODE` clauses migrating between `WITH` and the identifier across format passes.
 - Fix trailing comments on the last field of a SOSL `RETURNING X(...)` clause migrating outside the closing paren across format passes.
 
 ## Dependency Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,5 +42,7 @@ pnpm nx run prettier-plugin-apex:lint
 
 ## Agent workflow rules
 
-- **Before pushing**: run `pnpm nx run prettier-plugin-apex:lint` and fix any issues, then run the unit tests (`test:parser --configuration built-in`). Both must pass.
+- **Follow TDD.** For any change that touches the printer, parser, or comment-attachment logic, write a failing test fixture first (a `.cls` file under `packages/prettier-plugin-apex/tests/<feature>/` with a `jsfmt.spec.ts`), confirm it fails for the expected reason, then make the change. Snapshot-only PRs (test additions for already-working grammar) skip the red phase, but anything fixing or extending behavior must have a fixture that fails without the change.
+- **Changelog entry required for any change that affects formatted output.** Add a bullet under `# Unreleased` in `CHANGELOG.md` describing the user-visible behavior change. Bug fixes, layout changes, comment-handling changes, and new grammar support all qualify. Pure test additions, build/CI tweaks, internal refactors, and dependency bumps don't.
+- **Before pushing**: run `pnpm nx run prettier-plugin-apex:lint` and fix any issues, then run the unit tests (`test:parser --configuration built-in`). Both must pass. For changes touching the printer or comment logic, also run `AST_COMPARE=true …` to catch idempotency regressions.
 - **After completing a major feature**: verify that CLAUDE.md and the relevant README files still accurately describe the project.

--- a/packages/prettier-plugin-apex/src/printer.ts
+++ b/packages/prettier-plugin-apex/src/printer.ts
@@ -2087,6 +2087,7 @@ function handleReturningExpression(path: AstPath, print: PrintFn): Doc {
   if (selectDoc) {
     parts.push("(");
     parts.push(path.call(print, "select", "value"));
+    parts.push(softline);
     parts.push(")");
   }
   return groupConcat(parts);

--- a/packages/prettier-plugin-apex/tests/sosl/__snapshots__/FormattedSOSL1.cls
+++ b/packages/prettier-plugin-apex/tests/sosl/__snapshots__/FormattedSOSL1.cls
@@ -162,8 +162,8 @@ class SOSLClass {
       RETURNING
         My_Custom_Object__c(
           Id
-          WHERE
-            DISTANCE(My_Location_Field__c, GEOLOCATION(37, 122), 'mi') < 100)
+          WHERE DISTANCE(My_Location_Field__c, GEOLOCATION(37, 122), 'mi') < 100
+        )
     ];
   }
   void bindKeyword() {
@@ -184,7 +184,8 @@ class SOSLClass {
           WHERE
             PublishStatus = 'Online'
             AND language = 'en_US'
-            AND KnowledgeArticleVersion = 'ka230000000PCiy')
+            AND KnowledgeArticleVersion = 'ka230000000PCiy'
+        )
       UPDATE VIEWSTAT
     ];
     searchResult = [
@@ -192,7 +193,8 @@ class SOSLClass {
       RETURNING
         KnowledgeArticleVersion(
           Title
-          WHERE PublishStatus = 'Online' AND language = 'en_US')
+          WHERE PublishStatus = 'Online' AND language = 'en_US'
+        )
       UPDATE TRACKING
     ];
     searchResult = [
@@ -200,7 +202,8 @@ class SOSLClass {
       RETURNING
         KnowledgeArticleVersion(
           Title
-          WHERE PublishStatus = 'Online' AND language = 'en_US')
+          WHERE PublishStatus = 'Online' AND language = 'en_US'
+        )
       UPDATE TRACKING, VIEWSTAT
     ];
   }

--- a/packages/prettier-plugin-apex/tests/sosl_returning_comment/SOSLReturningComment.cls
+++ b/packages/prettier-plugin-apex/tests/sosl_returning_comment/SOSLReturningComment.cls
@@ -1,0 +1,94 @@
+class SOSLReturningComment {
+  void trailingLineCommentAfterLastField() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Name // trailing comment
+      )
+    ];
+  }
+
+  void trailingBlockCommentAfterLastField() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Name /* trailing block comment */
+      )
+    ];
+  }
+
+  void leadingCommentBeforeFirstField() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        // leading comment
+        Name
+      )
+    ];
+  }
+
+  void commentBetweenFields() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Id,
+        // between fields
+        Name
+      )
+    ];
+  }
+
+  void trailingCommentWithWhereClause() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Id,
+        Name // trailing comment
+        WHERE Name = 'Acme'
+      )
+    ];
+  }
+
+  void trailingCommentWithOrderByClause() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Id,
+        Name // trailing comment
+        ORDER BY Name ASC
+      )
+    ];
+  }
+
+  void trailingCommentWithLimitClause() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Id,
+        Name // trailing comment
+        LIMIT 10
+      )
+    ];
+  }
+
+  void commentAfterSubclauseInsideParens() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Id,
+        Name
+        WHERE Name = 'Acme' // trailing comment after where
+      )
+    ];
+  }
+
+  void trailingCommentWithUserMode() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(
+        Name // trailing comment
+      )
+      WITH USER_MODE
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/sosl_returning_comment/__snapshots__/FormattedSOSLReturningComment1.cls
+++ b/packages/prettier-plugin-apex/tests/sosl_returning_comment/__snapshots__/FormattedSOSLReturningComment1.cls
@@ -1,0 +1,100 @@
+class SOSLReturningComment {
+  void trailingLineCommentAfterLastField() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          Name // trailing comment
+        )
+    ];
+  }
+
+  void trailingBlockCommentAfterLastField() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING Account(Name /* trailing block comment */)
+    ];
+  }
+
+  void leadingCommentBeforeFirstField() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          // leading comment
+          Name
+        )
+    ];
+  }
+
+  void commentBetweenFields() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          Id,
+          // between fields
+          Name
+        )
+    ];
+  }
+
+  void trailingCommentWithWhereClause() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          Id,
+          Name // trailing comment
+          WHERE Name = 'Acme'
+        )
+    ];
+  }
+
+  void trailingCommentWithOrderByClause() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          Id,
+          Name // trailing comment
+          ORDER BY Name ASC
+        )
+    ];
+  }
+
+  void trailingCommentWithLimitClause() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          Id,
+          Name // trailing comment
+          LIMIT 10
+        )
+    ];
+  }
+
+  void commentAfterSubclauseInsideParens() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          Id,
+          Name
+          WHERE Name = 'Acme' // trailing comment after where
+        )
+    ];
+  }
+
+  void trailingCommentWithUserMode() {
+    List<List<SObject>> r = [
+      FIND 'Acme'
+      RETURNING
+        Account(
+          Name // trailing comment
+        )
+      WITH USER_MODE
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/sosl_returning_comment/jsfmt.spec.ts
+++ b/packages/prettier-plugin-apex/tests/sosl_returning_comment/jsfmt.spec.ts
@@ -1,0 +1,3 @@
+import { fileURLToPath } from "url";
+
+runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);

--- a/packages/prettier-plugin-apex/tests/sosl_user_mode/__snapshots__/FormattedSOSLUserMode1.cls
+++ b/packages/prettier-plugin-apex/tests/sosl_user_mode/__snapshots__/FormattedSOSLUserMode1.cls
@@ -79,7 +79,8 @@ class SOSLUserMode {
           BillingCountry
           WHERE Name LIKE 'Acme%'
           ORDER BY Name ASC
-          LIMIT 100),
+          LIMIT 100
+        ),
         Contact(Id, FirstName, LastName, Email LIMIT 50),
         Opportunity(Id, Name, Amount WHERE Amount > 1000 LIMIT 25)
       WITH USER_MODE


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

## The bug

A trailing comment after the last field in a SOSL `RETURNING X(...)` clause migrates outside the closing paren across format passes, so `AST_COMPARE=true` fails the stable-format check.

Input:
```apex
List<List<SObject>> r = [
  FIND 'Acme'
  RETURNING Account(
    Name // trailing comment
  )
];
```

After one format pass:
```apex
List<List<SObject>> r = [
  FIND 'Acme'
  RETURNING
    Account(
      Name) // trailing comment
];
```

On the next pass the layout collapses to a single line. The same thing happens for trailing comments after a `WHERE`/`ORDER BY`/`LIMIT` sub-clause inside the parens.

## Root cause

`handleReturningExpression` emits `name`, `(`, child group, `)` in sequence. The child (`ReturningSelectExpr`) is its own `groupIndentConcat` with a leading softline but nothing trailing, so the parent's `)` runs straight up against the last token. A trailing line-suffix comment on that token then flushes at the next available newline, which falls after `)`.

## Fix

Insert a `softline` before the closing paren in `handleReturningExpression`, mirroring what `handleSelectInnerQuery` already does for SOQL inner subqueries. The `)` now lands on its own line when the group breaks, and line-suffix comments inside the parens flush before it. The single-line `RETURNING Account(Name)` case is unchanged because softline collapses to empty when the group fits.

## Test plan

- New fixture `tests/sosl_returning_comment/` covers trailing line/block comments, leading and inter-field comments, the trailing-comment-after-sub-clause case, and the `WITH USER_MODE` interaction.
- `AST_COMPARE=true pnpm vitest run` passes across the full suite (258 tests).
- `pnpm nx run prettier-plugin-apex:lint` clean (3 pre-existing warnings, no new ones).
- A few pre-existing SOSL snapshots now put `)` on its own line when the field list breaks. That matches how SOQL inner subqueries already render, so it's a consistency win.

- [x] I've added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).