### PR TITLE
Drop Node 20 support, add Node 26 to test matrix

### DIFF
--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -32,16 +32,16 @@ jobs:
       fail-fast: false
       matrix:
         node:
+          - "26"
           - "25"
           - "24"
           - "22"
-          - "20"
         java:
           - "25"
           - "21"
           - "17"
         include:
-          - node: "20"
+          - node: "22"
             java: "17"
             ENABLE_CODE_COVERAGE: true
             ENABLE_INTEGRATION_TESTS: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Dependency Changes
 
-- Drop support for NodeJS < 20.
+- Drop support for NodeJS < 22.
 - Drop support for Java < 17.
 
 ## Internal Changes

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "version": "tsx scripts/release.zx.mts"
   },
   "engines": {
-    "node": ">= 20",
+    "node": ">= 22",
     "pnpm": "^11.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
     "@nx/shared-fs-cache": "5.0.5",
-    "@tsconfig/node20": "20.1.9",
-    "@types/node": "20.14.8",
+    "@tsconfig/node22": "22.0.5",
+    "@types/node": "22.19.19",
     "@types/semver": "7.7.1",
     "del-cli": "7.0.0",
     "nx": "22.7.2",

--- a/packages/prettier-plugin-apex/tsconfig.prod.json
+++ b/packages/prettier-plugin-apex/tsconfig.prod.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "include": ["src/**/*", "bin/**/*", "typings/global.d.ts"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       '@nx/shared-fs-cache':
         specifier: 5.0.5
         version: 5.0.5(nx@22.7.2)
-      '@tsconfig/node20':
-        specifier: 20.1.9
-        version: 20.1.9
+      '@tsconfig/node22':
+        specifier: 22.0.5
+        version: 22.0.5
       '@types/node':
-        specifier: 20.14.8
-        version: 20.14.8
+        specifier: 22.19.19
+        version: 22.19.19
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -94,13 +94,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
+        version: 6.0.2(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
       vite:
         specifier: 8.0.13
-        version: 8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
+        version: 8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
       vite-plugin-radar:
         specifier: 0.10.1
-        version: 0.10.1(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
+        version: 0.10.1(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
 
   packages/prettier-plugin-apex:
     dependencies:
@@ -122,10 +122,10 @@ importers:
         version: 4.1.6(vitest@4.1.6)
       vite:
         specifier: 8.0.13
-        version: 8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
+        version: 8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@types/node@20.14.8)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
+        version: 4.1.6(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
     optionalDependencies:
       '@prettier-apex/apex-ast-serializer-darwin-arm64':
         specifier: workspace:*
@@ -696,8 +696,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tsconfig/node20@20.1.9':
-    resolution: {integrity: sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==}
+  '@tsconfig/node22@22.0.5':
+    resolution: {integrity: sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -716,6 +716,9 @@ packages:
 
   '@types/node@20.14.8':
     resolution: {integrity: sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1643,6 +1646,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -2173,7 +2179,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tsconfig/node20@20.1.9': {}
+  '@tsconfig/node22@22.0.5': {}
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -2196,6 +2202,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -2213,10 +2223,10 @@ snapshots:
     dependencies:
       '@types/node': 20.14.8
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
@@ -2230,7 +2240,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@20.14.8)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
+      vitest: 4.1.6(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -2241,13 +2251,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -3173,6 +3183,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@6.21.0: {}
+
   unicorn-magic@0.3.0: {}
 
   use-debounce@10.1.1(react@19.2.6):
@@ -3181,11 +3193,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-radar@0.10.1(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)):
+  vite-plugin-radar@0.10.1(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)):
     dependencies:
-      vite: 8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
 
-  vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0):
+  vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3193,16 +3205,16 @@ snapshots:
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 20.14.8
+      '@types/node': 22.19.19
       esbuild: 0.28.0
       fsevents: 2.3.3
       tsx: 4.22.1
       yaml: 2.8.0
 
-  vitest@4.1.6(@types/node@20.14.8)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)):
+  vitest@4.1.6(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -3219,10 +3231,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@20.14.8)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.28.0)(tsx@4.22.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.14.8
+      '@types/node': 22.19.19
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
     transitivePeerDependencies:
       - msw

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "include": ["scripts/**/*.mts"],
   "compilerOptions": {
     "outDir": "./dist",


### PR DESCRIPTION
Node 20 reaches end-of-life later this year, so we're dropping it from the supported runtimes and rolling Node 26 in as the newest LTS-track entry in the CI test matrix.

## Changes

- **CI matrix** (`tests-deployments.yml`): replace `20` with `26` in the Node version list (`[26, 25, 24, 22]`). Move the coverage/integration-test pin from Node 20 + Java 17 to Node 22 + Java 17 so coverage runs against the new floor of supported runtimes.
- **Runtime floor**: bump root `package.json` `engines.node` from `>= 20` to `>= 22`.
- **Dev toolchain**: swap `@tsconfig/node20` → `@tsconfig/node22@22.0.5` and `@types/node@20` → `@types/node@22.19.19` so the TS toolchain tracks the new floor. Both `tsconfig.json` and `packages/prettier-plugin-apex/tsconfig.prod.json` updated to extend the node22 base.
- **CHANGELOG**: replace the unreleased `- Drop support for NodeJS < 20.` line with `- Drop support for NodeJS < 22.` (the prior entry was itself still unreleased).

## Out of scope

The publish, native-build, and package-test jobs still pin Node 24 — those are release-time pins, not support-matrix entries, and a bump there would warrant separate consideration (the publish job in particular notes a hard floor of Node 24 for OIDC Trusted Publishing).

## Test plan

- [x] `pnpm nx run prettier-plugin-apex:lint` (passes, 3 pre-existing warnings)
- [x] `pnpm nx run prettier-plugin-apex:build` (passes — verifies the `@tsconfig/node22` swap)
- [x] `pnpm nx run prettier-plugin-apex:test:parser --configuration built-in` (92/92 tests pass)
- [ ] CI matrix runs successfully on all 4 Node versions × 3 Java versions