### PR TITLE
Add plugin link metadata

### DIFF
--- a/packages/prettier-plugin-apex/package.json
+++ b/packages/prettier-plugin-apex/package.json
@@ -3,6 +3,10 @@
   "version": "2.3.0-beta.2",
   "description": "Salesforce Apex plugin for Prettier",
   "repository": "dangmai/prettier-plugin-apex",
+  "homepage": "https://github.com/dangmai/prettier-plugin-apex#readme",
+  "bugs": {
+    "url": "https://github.com/dangmai/prettier-plugin-apex/issues"
+  },
   "type": "module",
   "exports": "./dist/src/index.js",
   "browser": "dist/src/standalone.umd.cjs",


### PR DESCRIPTION
## Summary

- add npm `homepage` metadata for the README
- add npm `bugs.url` metadata for the public issue tracker

The published package currently lacks homepage and bugs links in npm package metadata.

## Verification

- `node -e "const p=require('./packages/prettier-plugin-apex/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,homepage:p.homepage,bugs:p.bugs},null,2)); if(p.name!=='prettier-plugin-apex'||p.homepage!=='https://github.com/dangmai/prettier-plugin-apex#readme'||p.bugs?.url!=='https://github.com/dangmai/prettier-plugin-apex/issues') process.exit(1)"`
- `git diff --check`