### PR TITLE
perf(serializer): ~1.9x faster native parsing via GraalVM build-time init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Improve parsing performance ~1.9x on multi-file runs via build-time initialization.
 - Fix trailing empty line not printed after ignored nodes in class declaration blocks ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1892)).
 - Fix standalone comments before SOQL `WITH SECURITY_ENFORCED` / `WITH USER_MODE` / `WITH SYSTEM_MODE` clauses migrating between `WITH` and the identifier across format passes.
 - Fix trailing comments on the last field of a SOSL `RETURNING X(...)` clause migrating outside the closing paren across format passes.

--- a/packages/apex-ast-serializer/parser/build.gradle
+++ b/packages/apex-ast-serializer/parser/build.gradle
@@ -157,6 +157,21 @@ graalvmNative {
       imageName = 'apex-ast-serializer'
       sharedLibrary = false
       buildArgs.add('--features=net.dangmai.serializer.RuntimeReflectionRegistrationFeature')
+      // Initialize the parser + serializer stack at image build time so a
+      // fresh process pays no jorje/XStream setup at first parse. This is a
+      // closure: a class is build-time-initializable only if everything it
+      // touches at init is too.
+      buildArgs.add('--initialize-at-build-time=org.antlr.runtime')
+      buildArgs.add('--initialize-at-build-time=apex.jorje.parser.impl')
+      buildArgs.add('--initialize-at-build-time=apex.jorje.data')
+      buildArgs.add('--initialize-at-build-time=apex.common')
+      buildArgs.add('--initialize-at-build-time=apex.jorje.semantic')
+      buildArgs.add('--initialize-at-build-time=net.dangmai.serializer')
+      buildArgs.add('--initialize-at-build-time=com.thoughtworks.xstream')
+      buildArgs.add('--initialize-at-build-time=com.google.common')
+      // -J targets the builder JVM; XStream reflects into java.io during init.
+      buildArgs.add('-J--add-opens=java.base/java.io=ALL-UNNAMED')
+      application.applicationDefaultJvmArgs.each { buildArgs.add('-J' + it) }
       buildArgs.addAll(application.applicationDefaultJvmArgs)
       // Certain Linux distribution doesn't allow dynamic-linked binaries to be
       // run, for example, NixOS, so we need to build a static binary.

--- a/packages/apex-ast-serializer/parser/src/main/java/net/dangmai/serializer/Apex.java
+++ b/packages/apex-ast-serializer/parser/src/main/java/net/dangmai/serializer/Apex.java
@@ -40,6 +40,12 @@ import org.apache.commons.io.IOUtils;
 
 public class Apex {
 
+  static {
+    // Required for correct comment retention; once at class init (baked into
+    // the native image) instead of per parse.
+    Locations.useIndexFactory();
+  }
+
   private static void setUpXStream(XStream xstream, int mode) {
     xstream.setMode(mode);
     xstream.registerConverter(
@@ -78,18 +84,23 @@ public class Apex {
     } else {
       engine = ParserEngine.get(ParserEngine.Type.NAMED);
     }
-    Locations.useIndexFactory(); // without this, comments won't be retained correctly
     ParserOutput output = engine.parse(
       sourceFile,
       ParserEngine.HiddenTokenBehavior.COLLECT_COMMENTS,
       ParserEngine.SoqlParserType.NEW
     );
 
-    // Serializing the output
-    int mode = XStream.NO_REFERENCES;
+    // Reuse the cached XStream; construction is expensive and would otherwise
+    // repeat on every parse.
+    XStream xstream = prettyPrint ? XStreams.PRETTY : XStreams.COMPACT;
+    synchronized (xstream) {
+      xstream.toXML(output, writer);
+    }
+  }
+
+  static XStream buildXStream(boolean prettyPrint) {
     Mapper defaultMapper = (new XStream()).getMapper();
-    XStream xstream;
-    xstream = new XStream(
+    XStream xstream = new XStream(
       null,
       new JsonHierarchicalStreamDriver() {
         @Override
@@ -102,7 +113,7 @@ public class Apex {
             new char[0],
             "".toCharArray(),
             JsonWriter.Format.SPACE_AFTER_LABEL |
-            JsonWriter.Format.COMPACT_EMPTY_ELEMENT
+              JsonWriter.Format.COMPACT_EMPTY_ELEMENT
           );
           return new CustomJsonWriter(writer, format);
         }
@@ -110,9 +121,8 @@ public class Apex {
       new ClassLoaderReference(new CompositeClassLoader()),
       new WithClassMapper(defaultMapper)
     );
-    setUpXStream(xstream, mode);
-
-    xstream.toXML(output, writer);
+    setUpXStream(xstream, XStream.NO_REFERENCES);
+    return xstream;
   }
 
   public static void main(String[] args) throws ParseException, IOException {

--- a/packages/apex-ast-serializer/parser/src/main/java/net/dangmai/serializer/XStreams.java
+++ b/packages/apex-ast-serializer/parser/src/main/java/net/dangmai/serializer/XStreams.java
@@ -1,0 +1,16 @@
+package net.dangmai.serializer;
+
+import com.thoughtworks.xstream.XStream;
+
+/**
+ * Cached XStream serializers, initialized at native-image build time
+ * (see --initialize-at-build-time in build.gradle) so a fresh process pays
+ * no XStream setup cost.
+ */
+final class XStreams {
+
+  static final XStream COMPACT = Apex.buildXStream(false);
+  static final XStream PRETTY = Apex.buildXStream(true);
+
+  private XStreams() {}
+}

--- a/packages/apex-ast-serializer/parser/src/test/java/net/dangmai/serializer/CliTest.java
+++ b/packages/apex-ast-serializer/parser/src/test/java/net/dangmai/serializer/CliTest.java
@@ -105,6 +105,28 @@ public class CliTest {
     });
   }
 
+  @Test
+  void shouldGetPrettyJsonFromNamedApexFile() {
+    assertDoesNotThrow(() -> {
+      TestUtilities.getApexTestFiles()
+        .forEach(file -> {
+          try {
+            byteArrayOutputStream = new ByteArrayOutputStream();
+            runCli(null, new String[] { "-p", "-l", file.getAbsolutePath() });
+
+            String content = byteArrayOutputStream.toString();
+            assertNotNull(content, "There should be content");
+            assertTrue(
+              TestUtilities.isJSONValid(content),
+              "Content should be valid JSON"
+            );
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    });
+  }
+
   private void runCli(final InputStream inputStream, final String[] params)
     throws Exception {
     final InputStream old = System.in;


### PR DESCRIPTION
There should not be any risk with the changes in this PR compared to the previous PR I created, just let me know hwt you think.

Initializes the parser + serializer at GraalVM native-image **build time**, so the ~34 ms of jorje/XStream setup is baked into the binary instead of re-paid by every spawned process.

spawn-per-file is unchanged, so `prettier.format()`, the experimental parallel CLI, and wrappers like `parallel-prettier` work the same. Just starts faster. performance compounds with #2403.

It does mean slightly larger binary (pre-initialized objects added to image heap).

### Flags (build.gradle)
- **[`--initialize-at-build-time=<pkg>`](https://www.graalvm.org/latest/reference-manual/native-image/guides/specify-class-initialization/)** 8 packages — `org.antlr.runtime`,
  `apex.jorje.parser.impl`, `apex.jorje.data`, `apex.common`, `apex.jorje.semantic`,
  `net.dangmai.serializer`, `com.thoughtworks.xstream`, `com.google.common`.
  - Runs each package's static initializers during the build and snapshots the result into image heap, so a fresh process skips that work.
- **`-J--add-opens=java.base/java.io=ALL-UNNAMED`** (plus existing `--add-opens` flags) 
  - XStream uses reflection to read Java's internal classes while starting up, Java blocks it. The app already opens it at runtime but because this setup now runs at build time the build's JVM needs the same permission. `-J` sends the flag to the build JVM only, the binary is unchanged.

Two small code changes:
- **`XStreams.java`** (new) — holds the two XStream serializers statically so they're built during build and stored in the binary instead of on every run.
- **`Apex.java`** — `useIndexFactory()` now runs once when the class loads (not per parse), and `getAST` re uses the stored XStream instead new each time.

### Performance
darwin-arm64, prettier 3.8.x. **base** = published non-BTI `2.3.0-beta.2`;
**this PR** = build-time-init binary; **+#2403** = plus the post-process PR.

| case | base | this PR | +#2403 |
| --- | --- | --- | --- |
| Serializer cold start (binary, tiny parse) | 39.8 ms | **12.8 ms (3.1x)** | 12.8 ms |
| `prettier --check` over 172 `.cls` files | 10.0 s | **5.2 s (1.9x)** | 5.1 s |
| Average per file (that run ÷ 172) | 58 ms | 30 ms | 30 ms |

#2403 seems flat here because that PR scales with file/ AST size and the files in this test are tiny.
Tested agsint a 2,422-line file #2403 cuts post-processing ~10.4 → ~5.9 ms (−43%).
