### PR TITLE
Split CLAUDE.md into scoped .claude/rules files

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,32 @@
+---
+description: >-
+  How comments are attached to and printed within the Apex AST. comments.ts is
+  the trickiest subsystem — jorje returns comments as hidden tokens and Prettier
+  must decide which node each one belongs to. Read this before touching comment
+  placement.
+paths:
+  - packages/prettier-plugin-apex/src/comments.ts
+---
+
+# Comment attachment
+
+`src/comments.ts` implements Prettier's comment-handler contract plus a pile of
+Apex-specific special cases. Comments are the most regression-prone area: a
+misplacement often only shows up as a comment drifting across format passes.
+
+- Prettier hook contract: `handleOwnLineComment`, `handleEndOfLineComment`,
+  `handleRemainingComment` each return `true` once they've placed a comment
+  (and `false` to let the default logic run). Supporting hooks: `canAttachComment`,
+  `willPrintOwnComments`, `isBlockComment`, `printComment`, `printDanglingComment`.
+- `isPrettierIgnore` recognizes `// prettier-ignore` / `/* prettier-ignore */`;
+  ignored nodes print their original source verbatim.
+- Special cases live here for dangling comments, WHERE-expression clauses,
+  block-statement leading comments, binaryish right-child trailing comments,
+  long method-call chains, `continue`/`break`/`return` dangling comments, and
+  modifier prettier-ignore. When adding a case, find the nearest existing
+  handler rather than adding a new top-level branch.
+- ApexDoc (`/** ... */`) has its own handling.
+
+Comment changes affect output and are easy to get subtly wrong: follow the TDD
+fixture workflow and **always run `AST_COMPARE=true`** to catch cross-pass
+drift — see `testing.md`.

--- a/.claude/rules/java-serializer.md
+++ b/.claude/rules/java-serializer.md
@@ -1,0 +1,48 @@
+---
+description: >-
+  The Java component that parses Apex (via Salesforce's jorje) and serializes the
+  AST to JSON for the plugin. Covers the pinned jorje dependency, XStream
+  serialization, generated typings, and the GraalVM native-image build. Read
+  this before changing anything under apex-ast-serializer.
+paths:
+  - packages/apex-ast-serializer/**/*
+---
+
+# apex-ast-serializer (Java)
+
+Parses an Apex class/trigger with jorje and serializes the AST to JSON on
+`stdout` (`parser/src/main/java/.../Apex.java`, via XStream with custom
+converters for Optional/TreeMap/enums). A long-running HTTP server
+(`server/...`) is the backend for the plugin's `built-in` mode.
+
+## jorje is proprietary and pinned — do not upgrade casually
+
+- `libs/apex-jorje-lsp.jar` is Salesforce's internal parser (minimized). A daily
+  CI workflow (`update-jorje.yml`) opens version-bump PRs; to update manually run
+  `tools/create-jorje-jar.sh`.
+- An AST-shape change ripples into the plugin's `printer.ts` and the generated
+  typings, so treat jorje bumps as potentially breaking.
+
+## Generated typings — never hand-edit
+
+`packages/prettier-plugin-apex/vendor/typings/jorje.d.ts` is **fully generated**
+by the Gradle `typescript-generator` plugin during `installDist`. Edit the
+generator config (`server/.../types/Custom*Extension.java`), not the output.
+
+## Native image & reflection
+
+- XStream serializes via runtime reflection, so the GraalVM native image needs
+  every jorje class/field registered: `RuntimeReflectionRegistrationFeature.java`
+  (uses ClassGraph). New reflective types may need attention there.
+- Requires Java >= 17; native images require GraalVM.
+
+## Build / test
+
+```bash
+./gradlew installDist                                # JVM dist -> plugin vendor/
+pnpm nx run apex-ast-serializer:build                # same, via Nx
+pnpm nx run apex-ast-serializer:build:native         # GraalVM native image
+pnpm nx run apex-ast-serializer:test                 # JUnit + JaCoCo
+```
+
+See `packages/apex-ast-serializer/README.md` for the full story.

--- a/.claude/rules/parser-modes.md
+++ b/.claude/rules/parser-modes.md
@@ -1,0 +1,42 @@
+---
+description: >-
+  How the plugin obtains the AST from the Java serializer — the three parser
+  modes, the HTTP server lifecycle, and the post-parse enrichment pass. Read
+  this before changing parser.ts, the server wiring, or the server bins.
+paths:
+  - packages/prettier-plugin-apex/src/parser.ts
+  - packages/prettier-plugin-apex/src/http-server.ts
+  - packages/prettier-plugin-apex/bin/*
+---
+
+# Parser modes & enrichment
+
+`src/parser.ts` gets the jorje AST from the Java `apex-ast-serializer`
+(`java-serializer.md`), `JSON.parse`s it, then runs a DFS **enrichment pass**
+that fixes/derives node locations and attaches layout metadata the printer
+relies on (`forcedHardline`, `EnrichedIfBlock`, trailing-empty-line flags).
+
+## The `apexStandaloneParser` option (three modes)
+
+- `native` (**default**) — spawn the prebuilt native binary per file, resolved
+  from the `@prettier-apex/*` package for the platform; falls back to the JVM
+  CLI if the binary is missing.
+- `built-in` — POST to a long-running HTTP server (`apexStandaloneHost` /
+  `apexStandalonePort` / `apexStandaloneProtocol`, default `localhost:2117`).
+  Fastest for repeated formats; needs the server up.
+- `none` — spawn the JVM CLI (`vendor/apex-ast-serializer/bin/...`) per file.
+
+## Server lifecycle
+
+```bash
+pnpm nx run prettier-plugin-apex:start-server   # start (backgrounds itself)
+pnpm nx run prettier-plugin-apex:wait-server    # block until reachable
+pnpm nx run prettier-plugin-apex:stop-server    # shut down via endpoint
+```
+
+Bins: `bin/start-apex-server.ts`, `bin/stop-apex-server.ts`. Tests pick the mode
+via the `APEX_PARSER` env var (the `built-in` vs `native` test configurations).
+
+Notes: spawns set `DEBUG=""` to dodge the Gradle Windows-wrapper verbose-log bug
+(#1513). The perf instrumentation seams in this file are covered by
+`performance-harness.md`.

--- a/.claude/rules/playground.md
+++ b/.claude/rules/playground.md
@@ -1,0 +1,24 @@
+---
+description: >-
+  The web playground — a React/Vite SPA that formats Apex in the browser using
+  the plugin's standalone build. Read this before changing anything under
+  packages/playground.
+paths:
+  - packages/playground/**/*
+---
+
+# Playground
+
+A React + Vite single-page app (deployed on Render) that lets users format Apex
+in the browser and share snippets via URL.
+
+- Entry/UI: `src/App.tsx`, `src/OptionEntry.tsx`, `src/Buttons.tsx`; shareable
+  state is encoded in the URL hash (`src/urlHash.ts`).
+- It consumes the plugin's **standalone UMD browser build**
+  (`dist/src/standalone.umd.cjs`), not the Node entry — so it can't spawn the
+  Java CLI or native binary. Browser parsing goes through the hosted HTTP
+  serializer; the `Dockerfile` builds that server image for deployment.
+- Because it runs in the browser, any plugin code reachable from the entry must
+  stay browser-safe: Node built-ins (`node:fs`, `node:child_process`, etc.) are
+  externalized in the UMD build and must not execute on the browser path.
+- It rarely needs changes and is largely self-contained.

--- a/.claude/rules/printer.md
+++ b/.claude/rules/printer.md
@@ -1,0 +1,31 @@
+---
+description: >-
+  How the Apex printer turns the jorje AST into formatted output. printer.ts is
+  the heart of formatting: it maps each jorje node type to Prettier doc-IR
+  builders. Read this before changing how any construct is laid out.
+paths:
+  - packages/prettier-plugin-apex/src/printer.ts
+  - packages/prettier-plugin-apex/src/constants.ts
+---
+
+# Printer (doc-IR formatting)
+
+`src/printer.ts` (~3.3k lines) is where formatting decisions live. The parser
+hands it an enriched jorje AST; the printer walks it and emits Prettier's
+**doc IR**, which Prettier then prints to a width-aware string.
+
+- Each jorje node type is identified by its `@class` string (catalogued as
+  `APEX_TYPES` in `src/constants.ts`). The printer dispatches on that class to a
+  dedicated `handle*` function (~166 of them) that builds the doc for that node.
+- Build docs with Prettier's doc builders: `group`, `indent`, `line`,
+  `softline`, `hardline`, `fill`, `join`, `conditionalGroup`. Local helpers
+  wrap common shapes: `indentConcat`, `groupConcat`, `groupIndentConcat`.
+- Layout heuristics that mirror the source (e.g. forcing hardlines in a SOQL
+  query the user wrote multi-line) are driven by metadata the parser attaches
+  during its enrichment pass — see `parser-modes.md`. The printer should rely on
+  that metadata rather than re-deriving layout from raw locations.
+- Background: Prettier's doc model (the `group`/`line`/`indent` algebra) and
+  Wadler-style pretty-printing. CONTRIBUTING.md links the canonical references.
+
+Any change here affects formatted output, so it needs the TDD fixture workflow
+and the changelog entry — see `testing.md`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,52 @@
+---
+description: >-
+  The test-driven workflow and commands for changing the plugin's formatting
+  (printer, parser, or comment-attachment logic). Read this before editing those
+  files or adding test fixtures.
+paths:
+  - packages/prettier-plugin-apex/src/printer.ts
+  - packages/prettier-plugin-apex/src/parser.ts
+  - packages/prettier-plugin-apex/src/comments.ts
+  - packages/prettier-plugin-apex/tests/**/*
+  - packages/prettier-plugin-apex/tests_config/**/*
+---
+
+# Testing & TDD workflow
+
+**Follow TDD for any change to the printer, parser, or comment-attachment
+logic.** Write a failing fixture first, confirm it fails for the expected
+reason, then implement.
+
+- A fixture is a `.cls`/`.trigger`/`.apex` file under
+  `packages/prettier-plugin-apex/tests/<feature>/` next to a `jsfmt.spec.ts`:
+
+  ```ts
+  import { fileURLToPath } from "url";
+  runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);
+  ```
+
+  Pass a third options argument to `runSpec` to exercise specific Prettier
+  options. Anonymous Apex uses the `apex-anonymous` parser.
+- Snapshot-only additions (tests for already-correct grammar) skip the red
+  phase; anything fixing or extending behavior must have a fixture that fails
+  without the change.
+
+## Commands
+
+```bash
+# Run unit tests (built-in HTTP server mode — preferred for local dev)
+pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
+# Native binary mode
+pnpm nx run prettier-plugin-apex:test:parser --configuration native
+# Update snapshots (always do this before opening a PR)
+pnpm nx run prettier-plugin-apex:test:parser --configuration built-in -u
+# AST comparison — validates the formatted output is semantically equivalent
+AST_COMPARE=true pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
+```
+
+Built-in mode needs the parser server running (`parser-modes.md`).
+
+**Before pushing** a formatting change: lint + built-in tests must pass, and for
+printer/comment changes also run `AST_COMPARE=true …` to catch idempotency /
+cross-pass regressions. Output-affecting changes also need a `CHANGELOG.md`
+entry (see root `CLAUDE.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,31 +18,20 @@ packages/
   @prettier-apex/            # Platform-specific native binary packages
 ```
 
-## Key commands
+## Universal workflow rules
 
-```bash
-# Start HTTP parsing server (needed for built-in mode; VSCode task does this automatically)
-pnpm nx run prettier-plugin-apex:start-server
+- **Before pushing**: run `pnpm nx run prettier-plugin-apex:lint` and the unit tests (`pnpm nx run prettier-plugin-apex:test:parser --configuration built-in`). Both must pass.
+- **Changelog entry required for any change that affects formatted output.** Add a bullet under `# Unreleased` in `CHANGELOG.md`. Bug fixes, layout changes, comment-handling changes, and new grammar support all qualify. Pure test additions, build/CI tweaks, internal refactors, and dependency bumps don't.
+- **After completing a major feature**: verify CLAUDE.md and the relevant README files still accurately describe the project.
 
-# Run unit tests (built-in HTTP server mode — preferred for local dev)
-pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
+## Scoped rules
 
-# Run unit tests (native binary mode)
-pnpm nx run prettier-plugin-apex:test:parser --configuration native
+Topic-specific guidance lives in `.claude/rules/` and auto-loads when you open matching files:
 
-# Update snapshots
-pnpm nx run prettier-plugin-apex:test:parser --configuration built-in -u
-
-# Run with AST comparison (validates semantic equivalence after formatting)
-AST_COMPARE=true pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
-
-# Lint
-pnpm nx run prettier-plugin-apex:lint
-```
-
-## Agent workflow rules
-
-- **Follow TDD.** For any change that touches the printer, parser, or comment-attachment logic, write a failing test fixture first (a `.cls` file under `packages/prettier-plugin-apex/tests/<feature>/` with a `jsfmt.spec.ts`), confirm it fails for the expected reason, then make the change. Snapshot-only PRs (test additions for already-working grammar) skip the red phase, but anything fixing or extending behavior must have a fixture that fails without the change.
-- **Changelog entry required for any change that affects formatted output.** Add a bullet under `# Unreleased` in `CHANGELOG.md` describing the user-visible behavior change. Bug fixes, layout changes, comment-handling changes, and new grammar support all qualify. Pure test additions, build/CI tweaks, internal refactors, and dependency bumps don't.
-- **Before pushing**: run `pnpm nx run prettier-plugin-apex:lint` and fix any issues, then run the unit tests (`test:parser --configuration built-in`). Both must pass. For changes touching the printer or comment logic, also run `AST_COMPARE=true …` to catch idempotency regressions.
-- **After completing a major feature**: verify that CLAUDE.md and the relevant README files still accurately describe the project.
+- `printer.md` — the doc-IR printer and node handlers
+- `comments.md` — comment attachment
+- `testing.md` — the TDD fixture workflow and test commands
+- `parser-modes.md` — native / built-in HTTP / CLI parser modes and the server
+- `java-serializer.md` — the Java / jorje / XStream / native-image component
+- `playground.md` — the web playground
+- `performance-harness.md` — performance benchmarking


### PR DESCRIPTION
The root `CLAUDE.md` had grown to mix universal workflow rules with subsystem-specific detail — the TDD fixture mechanics, the full test-command matrix, parser-mode notes — all of which load into *every* session regardless of what you're working on. Per Claude Code's own guidance (keep `CLAUDE.md` small; move single-area or multi-step guidance to path-scoped rules so it loads only when relevant), this trims root to the universal core plus an index and moves the rest into `.claude/rules/`.

`.claude/rules/*.md` are auto-discovered, and a rule with a `paths:` frontmatter glob loads **only when Claude reads a matching file** — so subsystem guidance is there when you need it and out of context when you don't.

New rule files (each scoped via `paths`):

- **printer.md** — the doc-IR printer and its ~166 node handlers (`src/printer.ts`, `src/constants.ts`)
- **comments.md** — comment-attachment logic, the trickiest subsystem (`src/comments.ts`)
- **testing.md** — the TDD fixture workflow + test commands + `AST_COMPARE` (printer/parser/comments + `tests/`)
- **parser-modes.md** — native / built-in HTTP / CLI parser modes + the server lifecycle (`src/parser.ts`, `src/http-server.ts`, `bin/`)
- **java-serializer.md** — the Java/jorje/XStream/native-image component + generated typings (`packages/apex-ast-serializer/`)
- **playground.md** — the React/Vite web playground (`packages/playground/`)

(`performance-harness.md` already existed.) Root `CLAUDE.md` drops to ~37 lines: intro, structure, the universal lint/test/changelog rules, and a pointer to the scoped rules.

No behavior change — documentation only.

- [ ] I've added tests to confirm my change works. <!-- N/A: documentation only. -->
- [ ] (If changing formatting output/API or CLI) I've added my changes to the \`CHANGELOG.md\` file in the \`Unreleased\` section. <!-- N/A: no change to formatted output, API, or CLI. -->
- [x] I've read the contributing guidelines.