### PR TITLE
Add label-gated benchmark CI workflow

### DIFF
--- a/.claude/rules/performance-harness.md
+++ b/.claude/rules/performance-harness.md
@@ -12,6 +12,7 @@ paths:
   - packages/prettier-plugin-apex/src/perf.ts
   - packages/prettier-plugin-apex/src/parser.ts
   - packages/apex-ast-serializer/parser/src/main/java/net/dangmai/serializer/Apex.java
+  - .github/workflows/benchmark.yml
 ---
 
 # Performance harness
@@ -31,7 +32,22 @@ driven by numbers rather than guesses.
 - `pnpm run benchmark:core` — the non-interactive core (`tests_perf/run.ts`).
   CI uses this directly after building the native binary. Flags: `--parser`,
   `--warmup`, `--iterations`, `--out <json>`, `--raw`, and a `compare
-  base.json head.json` subcommand.
+  base.json head.json [--markdown]` subcommand. `--markdown` emits a
+  GitHub-flavored table (used by the CI job summary + PR comment); plain compare
+  prints an ANSI console table. Invoke `compare` via `tsx` directly, not
+  `pnpm run benchmark:core --`, since pnpm forwards a literal `--` that shadows
+  the subcommand.
+
+## CI workflow
+
+`.github/workflows/benchmark.yml` runs the harness on a PR when it carries the
+`benchmark` label (report-only — it never fails the PR; GitHub runners are too
+noisy for a hard gate). In one job on one runner it builds the head native
+binary from source (sharing the scheduled build's NX cache, so a PR that doesn't
+touch the Java serializer skips the slow native-image build), downloads the
+latest scheduled `main` native artifact for the base side, benchmarks both
+back-to-back to cancel hardware variance, then renders `compare --markdown` into
+the job summary, a `benchmark-results` artifact, and a sticky PR comment.
 
 The harness benchmarks whatever the plugin's **default** mode is (currently
 `native`) unless `--parser` overrides it, so the numbers reflect a zero-config

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,41 +1,101 @@
 name: Benchmark
 
-# Label-gated performance comparison. Add the `benchmark` label to a PR to run
-# the perf harness on both the PR (head) and its base branch on the SAME runner,
-# then post the delta. It's report-only — it never fails the PR on a regression,
-# because GitHub-hosted runners are too noisy for a hard gate. The native build
-# is expensive, which is why this is opt-in via the label rather than always-on.
+# Performance harness runner. Three ways in:
+#   1. A PR carrying the `benchmark` label — benchmarks the PR (head) against its
+#      base branch and posts a sticky comment + job summary.
+#   2. workflow_dispatch on a branch — benchmarks that branch against `main`
+#      (summary + artifacts only, no comment). On `main` itself it just reports
+#      the absolute numbers, since there's nothing to compare against.
+#   3. workflow_dispatch with a `pr` number — benchmarks a contributor's PR (incl.
+#      forks) against `main`. Only repo collaborators can trigger workflow_dispatch,
+#      so this stays a maintainer-gated, review-then-run action (see the note on
+#      the `pr` input below).
+#
+# It's always report-only — it never fails on a regression, because GitHub-hosted
+# runners are too noisy for a hard gate. The native build is expensive, which is
+# why it's opt-in rather than always-on.
 
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: >-
+          PR number to benchmark against main (e.g. a fork PR). Leave empty to
+          benchmark the dispatched branch. SECURITY: this checks out and RUNS the
+          PR's code with this repo's token, so only dispatch it after reviewing
+          the PR's diff.
+        required: false
+        type: string
 
-# Read prior workflow artifacts (the daily main native build) and write a sticky
-# comment on the PR.
+# Read prior workflow artifacts (main's native build) and write a sticky comment.
 permissions:
   contents: read
   actions: read
   pull-requests: write
 
-# A new push supersedes an in-flight benchmark for the same PR.
+# A new push / dispatch supersedes an in-flight run for the same PR or branch.
 concurrency:
-  group: benchmark-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   benchmark:
-    name: Benchmark PR vs base
-    # Only run when the PR carries the `benchmark` label. On `labeled` the array
-    # already includes the just-added label, so this covers both "add the label
-    # to kick it off" and "re-run on push while the label is present".
-    if: contains(github.event.pull_request.labels.*.name, 'benchmark')
+    name: Benchmark
+    # PR path is label-gated; workflow_dispatch (collaborator-only) always runs.
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'benchmark')
     runs-on: ubuntu-latest
     env:
       OUTPUT_NAME: apex-ast-serializer-linux-x64
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout PR (head)
+      # Resolve what to benchmark and how to report, from the trigger context.
+      # Runs before checkout — it only reads the event payload, not the code.
+      - name: Resolve run parameters
+        id: setup
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_INPUT: ${{ github.event.inputs.pr }}
+          GH_REF: ${{ github.ref }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          head_ref="$GH_REF"
+          base_ref=""
+          compare=false
+          comment=false
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base_ref="$PR_BASE_REF"
+            compare=true
+            comment=true
+          elif [ -n "${PR_INPUT:-}" ]; then
+            if ! printf '%s' "$PR_INPUT" | grep -Eq '^[0-9]+$'; then
+              echo "::error::The 'pr' input must be a PR number."
+              exit 1
+            fi
+            head_ref="refs/pull/$PR_INPUT/merge"
+            base_ref="main"
+            compare=true
+          elif [ "$GH_REF_NAME" = "main" ]; then
+            compare=false
+          else
+            base_ref="main"
+            compare=true
+          fi
+          {
+            echo "head_ref=$head_ref"
+            echo "base_ref=$base_ref"
+            echo "compare=$compare"
+            echo "comment=$comment"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved: head_ref=$head_ref base_ref=$base_ref compare=$compare comment=$comment"
+
+      - name: Checkout head
         uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ steps.setup.outputs.head_ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.9
@@ -55,7 +115,7 @@ jobs:
           distribution: graalvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # ---- head: build the native binary from the PR source ----
+      # ---- head: build the native binary from source ----
       - name: Install head dependencies
         run: pnpm install --frozen-lockfile
 
@@ -63,8 +123,8 @@ jobs:
         run: chmod +x packages/apex-ast-serializer/gradlew
 
       # Share the native-build NX cache with the scheduled build job (same key):
-      # a PR that doesn't touch the Java serializer reuses main's compiled binary
-      # and skips the slow native-image build entirely.
+      # a build that doesn't touch the Java serializer reuses main's compiled
+      # binary and skips the slow native-image build entirely.
       - name: Restore native build NX cache
         id: nx-cache-restore
         uses: actions/cache/restore@v5.0.5
@@ -79,10 +139,14 @@ jobs:
       - name: Build head native executable
         run: pnpm nx run apex-ast-serializer:build:native
         env:
-          NX_KEY: ${{ secrets.NX_KEY }}
+          # Withhold the Nx Cloud token from untrusted fork-PR code (pr input);
+          # trusted contexts (own branches, same-repo PRs) still get the cache.
+          NX_KEY: ${{ github.event.inputs.pr == '' && secrets.NX_KEY || '' }}
 
+      # Only cache a SUCCESSFUL build — saving after a failure would poison the
+      # write-once cache key with an empty/partial .nx for the whole branch.
       - name: Save native build NX cache
-        if: always() && steps.nx-cache-restore.outputs.cache-hit != 'true'
+        if: success() && steps.nx-cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.5
         with:
           path: |
@@ -92,55 +156,56 @@ jobs:
       - name: Install head native binary
         run: pnpm run install:native:dev
 
-      # ---- base: download the latest main daily native build ----
+      # ---- base: download main's most recent native build ----
       # The build-native-executables job in tests-deployments.yml uploads this
-      # artifact on every scheduled (daily) and workflow_dispatch run.
+      # artifact on every scheduled and workflow_dispatch run; pick the newest.
       - name: Download base native binary
+        if: steps.setup.outputs.compare == 'true'
         run: |
           set -euo pipefail
-          find_run() {
-            gh run list --repo "$GITHUB_REPOSITORY" \
-              --workflow=tests-deployments.yml --branch=main \
-              --status=success --event="$1" --limit=1 \
-              --json databaseId --jq '.[0].databaseId // empty'
-          }
-          run_id=$(find_run schedule)
-          if [ -z "$run_id" ]; then run_id=$(find_run workflow_dispatch); fi
+          run_id=$(gh run list --repo "$GITHUB_REPOSITORY" \
+            --workflow=tests-deployments.yml --branch=main --status=success \
+            --limit=30 --json databaseId,event,createdAt \
+            --jq '[.[] | select(.event=="schedule" or .event=="workflow_dispatch")] | sort_by(.createdAt) | last | .databaseId // empty')
           if [ -z "$run_id" ]; then
-            echo "::error::No successful main native build found to use as the base binary. Trigger tests-deployments.yml on main (workflow_dispatch) and retry."
+            echo "::error::No successful scheduled/manual main native build found to use as the base binary. Trigger tests-deployments.yml on main (workflow_dispatch) and retry."
             exit 1
           fi
           echo "Using main native build from run $run_id"
           gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
             --name "$OUTPUT_NAME" --dir "$RUNNER_TEMP/base-bin"
 
-      # Check the base branch out only now that all head Nx work is done. Nx
-      # scans the whole tree for project.json files, so a base/ checkout present
-      # during the head native build would collide with the head's projects
-      # ("defined in multiple locations"). The base side runs only tsx, never Nx.
+      # Check the base branch out only now that all head Nx work is done. Nx scans
+      # the whole tree for project.json files, so a base/ checkout present during
+      # the head native build would collide ("defined in multiple locations").
+      # The base side runs only tsx, never Nx.
       - name: Checkout base branch
+        if: steps.setup.outputs.compare == 'true'
         uses: actions/checkout@v6.0.3
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ steps.setup.outputs.base_ref }}
           path: base
 
       - name: Install base dependencies
+        if: steps.setup.outputs.compare == 'true'
         working-directory: base
         run: pnpm install --frozen-lockfile
 
       # install:native:ci expects every platform's binary at once, so copy the
       # single linux artifact straight into the base checkout's native package.
       - name: Install base native binary
+        if: steps.setup.outputs.compare == 'true'
         run: |
           set -euo pipefail
           dest="base/packages/@prettier-apex/$OUTPUT_NAME"
           cp "$RUNNER_TEMP/base-bin/$OUTPUT_NAME" "$dest/$OUTPUT_NAME"
           chmod +x "$dest/$OUTPUT_NAME"
 
-      # ---- run both benchmarks back-to-back on this one runner ----
+      # ---- run the benchmarks back-to-back on this one runner ----
       # tsx is invoked directly (not `pnpm run benchmark:core --`) because pnpm
-      # forwards a literal `--` that would shadow the `compare` subcommand.
+      # forwards a literal `--` that would shadow the compare/report subcommand.
       - name: Benchmark base
+        if: steps.setup.outputs.compare == 'true'
         working-directory: base/packages/prettier-plugin-apex
         run: |
           set -euo pipefail
@@ -155,10 +220,19 @@ jobs:
           node -e "if (require('$RUNNER_TEMP/head.json').meta.usingFallback) { console.error('Head fell back to the JVM serializer — native binary missing.'); process.exit(1); }"
 
       - name: Render comparison
+        if: steps.setup.outputs.compare == 'true'
         run: |
           set -euo pipefail
           pnpm exec tsx packages/prettier-plugin-apex/tests_perf/run.ts \
             compare "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/head.json" --markdown \
+            | tee "$RUNNER_TEMP/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Render report
+        if: steps.setup.outputs.compare != 'true'
+        run: |
+          set -euo pipefail
+          pnpm exec tsx packages/prettier-plugin-apex/tests_perf/run.ts \
+            report "$RUNNER_TEMP/head.json" \
             | tee "$RUNNER_TEMP/report.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload result JSON
@@ -168,9 +242,11 @@ jobs:
           path: |
             ${{ runner.temp }}/base.json
             ${{ runner.temp }}/head.json
+          if-no-files-found: ignore
           retention-days: 30
 
       - name: Post sticky PR comment
+        if: steps.setup.outputs.comment == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,177 @@
+name: Benchmark
+
+# Label-gated performance comparison. Add the `benchmark` label to a PR to run
+# the perf harness on both the PR (head) and its base branch on the SAME runner,
+# then post the delta. It's report-only — it never fails the PR on a regression,
+# because GitHub-hosted runners are too noisy for a hard gate. The native build
+# is expensive, which is why this is opt-in via the label rather than always-on.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+# Read prior workflow artifacts (the daily main native build) and write a sticky
+# comment on the PR.
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+# A new push supersedes an in-flight benchmark for the same PR.
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark PR vs base
+    # Only run when the PR carries the `benchmark` label. On `labeled` the array
+    # already includes the just-added label, so this covers both "add the label
+    # to kick it off" and "re-run on push while the label is present".
+    if: contains(github.event.pull_request.labels.*.name, 'benchmark')
+    runs-on: ubuntu-latest
+    env:
+      OUTPUT_NAME: apex-ast-serializer-linux-x64
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout PR (head)
+        uses: actions/checkout@v6.0.3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # GraalVM is needed only to build the head native binary; the harness runs
+      # the binary directly, so the benchmark steps don't touch the JVM.
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1.5.5
+        with:
+          java-version: "23"
+          distribution: graalvm
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ---- head: build the native binary from the PR source ----
+      - name: Install head dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x packages/apex-ast-serializer/gradlew
+
+      # Share the native-build NX cache with the scheduled build job (same key):
+      # a PR that doesn't touch the Java serializer reuses main's compiled binary
+      # and skips the slow native-image build entirely.
+      - name: Restore native build NX cache
+        id: nx-cache-restore
+        uses: actions/cache/restore@v5.0.5
+        with:
+          path: |
+            .nx
+          key: ubuntu-latest-nx-build-native-${{ hashFiles('packages/apex-ast-serializer/parser/**/*.java', 'packages/apex-ast-serializer/parser/**/*.properties', 'packages/apex-ast-serializer/parser/build.gradle', 'packages/apex-ast-serializer/libs/*.jar', 'packages/apex-ast-serializer/tools/build-native-binary.mjs') }}
+
+      - name: Build Linux musl toolchain
+        run: pnpm nx run apex-ast-serializer:build:musl
+
+      - name: Build head native executable
+        run: pnpm nx run apex-ast-serializer:build:native
+        env:
+          NX_KEY: ${{ secrets.NX_KEY }}
+
+      - name: Save native build NX cache
+        if: always() && steps.nx-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5.0.5
+        with:
+          path: |
+            .nx
+          key: ${{ steps.nx-cache-restore.outputs.cache-primary-key }}
+
+      - name: Install head native binary
+        run: pnpm run install:native:dev
+
+      # ---- base: download the latest main daily native build ----
+      # The build-native-executables job in tests-deployments.yml uploads this
+      # artifact on every scheduled (daily) and workflow_dispatch run.
+      - name: Download base native binary
+        run: |
+          set -euo pipefail
+          find_run() {
+            gh run list --repo "$GITHUB_REPOSITORY" \
+              --workflow=tests-deployments.yml --branch=main \
+              --status=success --event="$1" --limit=1 \
+              --json databaseId --jq '.[0].databaseId // empty'
+          }
+          run_id=$(find_run schedule)
+          if [ -z "$run_id" ]; then run_id=$(find_run workflow_dispatch); fi
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful main native build found to use as the base binary. Trigger tests-deployments.yml on main (workflow_dispatch) and retry."
+            exit 1
+          fi
+          echo "Using main native build from run $run_id"
+          gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+            --name "$OUTPUT_NAME" --dir "$RUNNER_TEMP/base-bin"
+
+      # Check the base branch out only now that all head Nx work is done. Nx
+      # scans the whole tree for project.json files, so a base/ checkout present
+      # during the head native build would collide with the head's projects
+      # ("defined in multiple locations"). The base side runs only tsx, never Nx.
+      - name: Checkout base branch
+        uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base
+
+      - name: Install base dependencies
+        working-directory: base
+        run: pnpm install --frozen-lockfile
+
+      # install:native:ci expects every platform's binary at once, so copy the
+      # single linux artifact straight into the base checkout's native package.
+      - name: Install base native binary
+        run: |
+          set -euo pipefail
+          dest="base/packages/@prettier-apex/$OUTPUT_NAME"
+          cp "$RUNNER_TEMP/base-bin/$OUTPUT_NAME" "$dest/$OUTPUT_NAME"
+          chmod +x "$dest/$OUTPUT_NAME"
+
+      # ---- run both benchmarks back-to-back on this one runner ----
+      # tsx is invoked directly (not `pnpm run benchmark:core --`) because pnpm
+      # forwards a literal `--` that would shadow the `compare` subcommand.
+      - name: Benchmark base
+        working-directory: base/packages/prettier-plugin-apex
+        run: |
+          set -euo pipefail
+          pnpm exec tsx tests_perf/run.ts --parser native --out "$RUNNER_TEMP/base.json"
+          node -e "if (require('$RUNNER_TEMP/base.json').meta.usingFallback) { console.error('Base fell back to the JVM serializer — native binary missing.'); process.exit(1); }"
+
+      - name: Benchmark head
+        working-directory: packages/prettier-plugin-apex
+        run: |
+          set -euo pipefail
+          pnpm exec tsx tests_perf/run.ts --parser native --out "$RUNNER_TEMP/head.json"
+          node -e "if (require('$RUNNER_TEMP/head.json').meta.usingFallback) { console.error('Head fell back to the JVM serializer — native binary missing.'); process.exit(1); }"
+
+      - name: Render comparison
+        run: |
+          set -euo pipefail
+          pnpm exec tsx packages/prettier-plugin-apex/tests_perf/run.ts \
+            compare "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/head.json" --markdown \
+            | tee "$RUNNER_TEMP/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload result JSON
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: benchmark-results
+          path: |
+            ${{ runner.temp }}/base.json
+            ${{ runner.temp }}/head.json
+          retention-days: 30
+
+      - name: Post sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: benchmark
+          path: ${{ runner.temp }}/report.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - Replace `eslint` with `biome` for linting purpose.
 - Add a performance benchmark harness for profiling where time goes during formatting.
-- Add a label-gated CI workflow that benchmarks a PR against its base branch and reports the deltas.
+- Add a CI workflow that benchmarks a labeled PR against its base branch, and can also be run manually on any branch or against a contributor's PR.
 
 # 2.2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Replace `eslint` with `biome` for linting purpose.
 - Add a performance benchmark harness for profiling where time goes during formatting.
+- Add a label-gated CI workflow that benchmarks a PR against its base branch and reports the deltas.
 
 # 2.2.6
 

--- a/packages/prettier-plugin-apex/tests_perf/run.ts
+++ b/packages/prettier-plugin-apex/tests_perf/run.ts
@@ -337,6 +337,44 @@ async function runBenchmark(argv: string[]): Promise<void> {
   }
 }
 
+function bucketLabel(bucket: Bucket, isSub: boolean): string {
+  return bucket === "total" ? "**total**" : isSub ? `└ ${bucket}` : bucket;
+}
+
+// Renders a single benchmark run as a markdown table (no comparison). Used when
+// there is nothing to compare against — e.g. a workflow_dispatch run on `main`.
+function reportMarkdown(file: string): string {
+  const data = JSON.parse(readFileSync(file, "utf8"));
+  const m = data.meta ?? {};
+  const out: string[] = [];
+  out.push(`## Performance benchmark — \`${m.gitSha ?? "?"}\``);
+  out.push("");
+  out.push(
+    `Mode: \`${m.mode ?? "?"}\` · ${m.node ?? "?"} · ${m.platform ?? "?"}-${m.arch ?? "?"} · ${m.warmup ?? "?"} warmup + ${m.iterations ?? "?"} measured iterations`,
+  );
+  out.push("");
+  out.push(
+    "> ⚠️ Run on a shared GitHub-hosted runner — treat small numbers as noise.",
+  );
+  for (const name of Object.keys(data.results)) {
+    const r: FileResult = data.results[name];
+    const hasSub = r["java-parse"].median > 0 || r["java-serialize"].median > 0;
+    out.push("");
+    out.push(`### ${name}`);
+    out.push("");
+    out.push("| bucket | median (ms) |");
+    out.push("| --- | ---: |");
+    for (const bucket of BUCKETS) {
+      if (!r[bucket]) continue;
+      const isSub = (SUB_BUCKETS as readonly string[]).includes(bucket);
+      if (isSub && !hasSub) continue;
+      out.push(`| ${bucketLabel(bucket, isSub)} | ${r[bucket].median.toFixed(3)} |`);
+    }
+  }
+  out.push("");
+  return out.join("\n");
+}
+
 // Renders the base-vs-head comparison as GitHub-flavored markdown, for the CI
 // job summary and the sticky PR comment. Kept here (rather than in the workflow)
 // so the bucket list and delta math stay shared with the console renderer.
@@ -361,6 +399,10 @@ function compareMarkdown(baseFile: string, headFile: string): string {
   out.push("");
   out.push(
     "> ⚠️ Run on a shared GitHub-hosted runner, report-only. Both sides ran back-to-back on the same machine to cancel hardware variance, but small deltas (a few %) are still noise — look for consistent, sizeable shifts.",
+  );
+  out.push("");
+  out.push(
+    "> ℹ️ Base is the most recent `main` native build (gitSha above); it can lag `main`'s current tip if no newer scheduled/manual build has run since.",
   );
 
   const emittedSub = (r: FileResult): boolean =>
@@ -400,12 +442,7 @@ function compareMarkdown(baseFile: string, headFile: string): string {
       const hm = h[bucket].median;
       const delta = hm - bm;
       const pct = bm ? (delta / bm) * 100 : 0;
-      const label =
-        bucket === "total"
-          ? "**total**"
-          : isSub
-            ? `└ ${bucket}`
-            : bucket;
+      const label = bucketLabel(bucket, isSub);
       // When the base lacks the Java split, comparing head's sub-buckets to an
       // all-zero base is meaningless — show the head value but suppress the delta.
       if (isSub && !baseHasSub) {
@@ -471,6 +508,15 @@ if (maybeSub === "compare") {
   } else {
     runCompare(baseFile, headFile);
   }
+} else if (maybeSub === "report") {
+  // Single-run markdown table, for when there's no base to compare against
+  // (e.g. a workflow_dispatch run on main).
+  const positional = rest.filter((a) => !a.startsWith("--"));
+  if (positional.length < 1) {
+    console.error("Usage: run.ts report results.json");
+    process.exit(1);
+  }
+  process.stdout.write(reportMarkdown(positional[0] as string));
 } else {
   await runBenchmark(process.argv.slice(2));
 }

--- a/packages/prettier-plugin-apex/tests_perf/run.ts
+++ b/packages/prettier-plugin-apex/tests_perf/run.ts
@@ -363,11 +363,30 @@ function compareMarkdown(baseFile: string, headFile: string): string {
     "> ⚠️ Run on a shared GitHub-hosted runner, report-only. Both sides ran back-to-back on the same machine to cancel hardware variance, but small deltas (a few %) are still noise — look for consistent, sizeable shifts.",
   );
 
+  const emittedSub = (r: FileResult): boolean =>
+    r["java-parse"].median > 0 || r["java-serialize"].median > 0;
+  // The base binary can predate the Java-side timing instrumentation (e.g. the
+  // latest scheduled main build is older than that change), in which case it
+  // emits no transport sub-split. Detect that so we don't print misleading
+  // sub-bucket deltas against an all-zero base.
+  const baseMissingSplit = Object.keys(head.results).some((name) => {
+    const b: FileResult | undefined = base.results[name];
+    const h: FileResult = head.results[name];
+    return b && emittedSub(h) && !emittedSub(b);
+  });
+  if (baseMissingSplit) {
+    out.push("");
+    out.push(
+      "> ℹ️ The base binary emitted no transport breakdown (it predates the Java-side timing instrumentation), so its sub-buckets show `n/a`. This resolves once main's scheduled native build includes the instrumentation.",
+    );
+  }
+
   for (const name of Object.keys(head.results)) {
     const b: FileResult | undefined = base.results[name];
     const h: FileResult = head.results[name];
     if (!b) continue;
-    const hasSub = h["java-parse"].median > 0 || h["java-serialize"].median > 0;
+    const hasSub = emittedSub(h);
+    const baseHasSub = emittedSub(b);
     out.push("");
     out.push(`### ${name}`);
     out.push("");
@@ -387,6 +406,12 @@ function compareMarkdown(baseFile: string, headFile: string): string {
           : isSub
             ? `└ ${bucket}`
             : bucket;
+      // When the base lacks the Java split, comparing head's sub-buckets to an
+      // all-zero base is meaningless — show the head value but suppress the delta.
+      if (isSub && !baseHasSub) {
+        out.push(`| ${label} | n/a | ${hm.toFixed(3)} | — | — |`);
+        continue;
+      }
       const pctStr = `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
       out.push(
         `| ${label} | ${bm.toFixed(3)} | ${hm.toFixed(3)} | ${delta >= 0 ? "+" : ""}${delta.toFixed(3)} | ${pctStr} |`,

--- a/packages/prettier-plugin-apex/tests_perf/run.ts
+++ b/packages/prettier-plugin-apex/tests_perf/run.ts
@@ -337,6 +337,66 @@ async function runBenchmark(argv: string[]): Promise<void> {
   }
 }
 
+// Renders the base-vs-head comparison as GitHub-flavored markdown, for the CI
+// job summary and the sticky PR comment. Kept here (rather than in the workflow)
+// so the bucket list and delta math stay shared with the console renderer.
+function compareMarkdown(baseFile: string, headFile: string): string {
+  const base = JSON.parse(readFileSync(baseFile, "utf8"));
+  const head = JSON.parse(readFileSync(headFile, "utf8"));
+  const m = head.meta ?? {};
+  const out: string[] = [];
+  out.push(
+    `## Performance benchmark — base \`${base.meta?.gitSha ?? "?"}\` vs head \`${head.meta?.gitSha ?? "?"}\``,
+  );
+  out.push("");
+  out.push(
+    `Mode: \`${m.mode ?? "?"}\` · ${m.node ?? "?"} · ${m.platform ?? "?"}-${m.arch ?? "?"} · ${m.warmup ?? "?"} warmup + ${m.iterations ?? "?"} measured iterations`,
+  );
+  if (base.meta?.mode !== head.meta?.mode) {
+    out.push("");
+    out.push(
+      `> ⚠️ Mode mismatch: base=\`${base.meta?.mode}\` head=\`${head.meta?.mode}\``,
+    );
+  }
+  out.push("");
+  out.push(
+    "> ⚠️ Run on a shared GitHub-hosted runner, report-only. Both sides ran back-to-back on the same machine to cancel hardware variance, but small deltas (a few %) are still noise — look for consistent, sizeable shifts.",
+  );
+
+  for (const name of Object.keys(head.results)) {
+    const b: FileResult | undefined = base.results[name];
+    const h: FileResult = head.results[name];
+    if (!b) continue;
+    const hasSub = h["java-parse"].median > 0 || h["java-serialize"].median > 0;
+    out.push("");
+    out.push(`### ${name}`);
+    out.push("");
+    out.push("| bucket | base (ms) | head (ms) | Δ (ms) | Δ% |");
+    out.push("| --- | ---: | ---: | ---: | ---: |");
+    for (const bucket of BUCKETS) {
+      if (!b[bucket] || !h[bucket]) continue;
+      const isSub = (SUB_BUCKETS as readonly string[]).includes(bucket);
+      if (isSub && !hasSub) continue;
+      const bm = b[bucket].median;
+      const hm = h[bucket].median;
+      const delta = hm - bm;
+      const pct = bm ? (delta / bm) * 100 : 0;
+      const label =
+        bucket === "total"
+          ? "**total**"
+          : isSub
+            ? `└ ${bucket}`
+            : bucket;
+      const pctStr = `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+      out.push(
+        `| ${label} | ${bm.toFixed(3)} | ${hm.toFixed(3)} | ${delta >= 0 ? "+" : ""}${delta.toFixed(3)} | ${pctStr} |`,
+      );
+    }
+  }
+  out.push("");
+  return out.join("\n");
+}
+
 function runCompare(baseFile: string, headFile: string): void {
   const base = JSON.parse(readFileSync(baseFile, "utf8"));
   const head = JSON.parse(readFileSync(headFile, "utf8"));
@@ -373,11 +433,19 @@ function runCompare(baseFile: string, headFile: string): void {
 
 const [, , maybeSub, ...rest] = process.argv;
 if (maybeSub === "compare") {
-  if (rest.length < 2) {
-    console.error("Usage: run.ts compare base.json head.json");
+  const positional = rest.filter((a) => !a.startsWith("--"));
+  if (positional.length < 2) {
+    console.error("Usage: run.ts compare base.json head.json [--markdown]");
     process.exit(1);
   }
-  runCompare(rest[0] as string, rest[1] as string);
+  const [baseFile, headFile] = positional as [string, string];
+  if (rest.includes("--markdown")) {
+    // Emit only the markdown report to stdout, so CI can pipe it straight into
+    // $GITHUB_STEP_SUMMARY / a PR comment without ANSI noise.
+    process.stdout.write(compareMarkdown(baseFile, headFile));
+  } else {
+    runCompare(baseFile, headFile);
+  }
 } else {
   await runBenchmark(process.argv.slice(2));
 }


### PR DESCRIPTION
This adds the CI half of the performance harness that landed in #2407. The harness already produces machine-readable JSON and a `compare` subcommand; this wires it into GitHub Actions so we can see a change's perf impact on demand, without hand-running the wizard.

## How it works

Three ways in, all report-only (they never fail on a regression — GitHub runners are too noisy to gate on):

1. **Label a PR `benchmark`** → benchmarks the PR (head) against its base branch and posts a sticky comment + job summary.
2. **`workflow_dispatch` on a branch** → benchmarks that branch against `main` (summary + artifacts, no comment). On `main` itself it just reports absolute numbers, since there's nothing to compare against.
3. **`workflow_dispatch` with a `pr` number** → benchmarks a contributor's PR (incl. forks) against `main`. See the security note below.

In all cases, a single job on a single runner builds the **head** native binary from source, downloads **main**'s most recent native artifact for the **base**, benchmarks both back-to-back, and renders the per-bucket deltas.

A few deliberate choices:

- **Same runner, back-to-back.** GitHub runners are noisy, so the only trustworthy comparison is base and head on the same machine in the same job — splitting them wouldn't cancel the variance.
- **Build head / download base.** Head must be built (no prebuilt artifact exists for an arbitrary branch). To avoid always paying the native-image cost, the head build shares the scheduled build job's Nx cache key, so a change that doesn't touch the Java serializer reuses main's compiled binary. The cache is only saved on a *successful* build (a failed build was poisoning the write-once key).
- **Markdown lives in the harness.** Added `--markdown` to `compare` and a `report` subcommand for the no-base case, rather than re-implementing tables in YAML — the bucket list and delta math stay in one place.

## Running against fork PRs without `pull_request_target`

`workflow_dispatch` can only be triggered by repo collaborators, so the `pr`-number path is a **maintainer-gated, review-then-run** action: you review the contributor's diff, then dispatch `-f pr=<N>`, which checks out `refs/pull/<N>/merge` and runs it. This is strictly safer than `pull_request_target` (which would auto-run untrusted code in a privileged context). As defense-in-depth, the Nx Cloud token is withheld from `pr`-input runs so untrusted code can't reach it.

## Known limitations

- Base lookup assumes the target is `main` (where the native build runs). The base binary is main's most recent native build, which can lag main's tip — the report notes this and prints the base gitSha.
- Fork PRs get a read-only token on the `pull_request` trigger, so the auto sticky-comment path won't work for them — that's what the maintainer-triggered `pr` dispatch is for.

Verified end-to-end on this PR: label-gating (skips unlabeled, runs when labeled), the native build, base download, both benchmarks, the markdown render, artifact upload, and the sticky comment all pass. A both-instrumented run confirms `java-serialize` (~250ms) is ~88% of transport on the large fixture — the XStream-serialize cost this harness exists to track.

- [ ] I've added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).
