### PR TITLE
Stop the benchmark workflow from evicting main's native cache

### DIFF
--- a/.claude/rules/performance-harness.md
+++ b/.claude/rules/performance-harness.md
@@ -43,8 +43,10 @@ driven by numbers rather than guesses.
 `.github/workflows/benchmark.yml` runs the harness on a PR when it carries the
 `benchmark` label (report-only — it never fails the PR; GitHub runners are too
 noisy for a hard gate). In one job on one runner it builds the head native
-binary from source (sharing the scheduled build's NX cache, so a PR that doesn't
-touch the Java serializer skips the slow native-image build), downloads the
+binary from source (reusing the scheduled build's NX cache via `restore-keys`
+for reads — so a PR that doesn't touch the Java serializer skips the slow
+native-image build — while saving under a `benchmark-` prefixed key so it never
+displaces main's canonical cache), downloads the
 latest scheduled `main` native artifact for the base side, benchmarks both
 back-to-back to cancel hardware variance, then renders `compare --markdown` into
 the job summary, a `benchmark-results` artifact, and a sticky PR comment.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -122,16 +122,22 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x packages/apex-ast-serializer/gradlew
 
-      # Share the native-build NX cache with the scheduled build job (same key):
-      # a build that doesn't touch the Java serializer reuses main's compiled
-      # binary and skips the slow native-image build entirely.
+      # Reuse the scheduled build's native-image cache for READS, but never write
+      # the shared key: a GitHub cache key is single-owner per repo, so saving the
+      # `ubuntu-latest-nx-build-native-*` key here would displace main's canonical
+      # copy (re-scoping it to the PR ref). Instead, save under a `benchmark-`
+      # prefixed key and fall back to main's key via restore-keys. A build that
+      # doesn't touch the Java serializer still replays main's cached binary; a
+      # branch's own repeat runs hit the benchmark- key; main's cache is untouched.
       - name: Restore native build NX cache
         id: nx-cache-restore
         uses: actions/cache/restore@v5.0.5
         with:
           path: |
             .nx
-          key: ubuntu-latest-nx-build-native-${{ hashFiles('packages/apex-ast-serializer/parser/**/*.java', 'packages/apex-ast-serializer/parser/**/*.properties', 'packages/apex-ast-serializer/parser/build.gradle', 'packages/apex-ast-serializer/libs/*.jar', 'packages/apex-ast-serializer/tools/build-native-binary.mjs') }}
+          key: benchmark-ubuntu-latest-nx-build-native-${{ hashFiles('packages/apex-ast-serializer/parser/**/*.java', 'packages/apex-ast-serializer/parser/**/*.properties', 'packages/apex-ast-serializer/parser/build.gradle', 'packages/apex-ast-serializer/libs/*.jar', 'packages/apex-ast-serializer/tools/build-native-binary.mjs') }}
+          restore-keys: |
+            ubuntu-latest-nx-build-native-${{ hashFiles('packages/apex-ast-serializer/parser/**/*.java', 'packages/apex-ast-serializer/parser/**/*.properties', 'packages/apex-ast-serializer/parser/build.gradle', 'packages/apex-ast-serializer/libs/*.jar', 'packages/apex-ast-serializer/tools/build-native-binary.mjs') }}
 
       - name: Build Linux musl toolchain
         run: pnpm nx run apex-ast-serializer:build:musl


### PR DESCRIPTION
Follow-up to #2410. While verifying the benchmark workflow, I noticed it was evicting `main`'s native-build Nx cache, forcing every benchmark run to rebuild the GraalVM native image from scratch (~7–9 min instead of a cache replay).

## Root cause

The benchmark job both **restored and saved** the shared `<os>-nx-build-native-<hash>` key — the same key `tests-deployments.yml` uses for the scheduled native build. A GitHub Actions cache key is effectively single-owner per repo, so when the benchmark run (on a PR ref) saved that key, it **displaced main's canonical copy**, re-scoping it to the PR ref. The next benchmark run then found nothing to restore and rebuilt.

I confirmed this from the logs: `tests-deployments.yml`'s ubuntu native job saved `ubuntu-latest-nx-build-native-<hash>` successfully, but minutes later the benchmark run saved the identical key on the PR ref — and afterward only the macOS/Windows copies (which never got a second save) survived on `main`.

## Fix

Read main's cache but never write its key:

- `key:` → `benchmark-ubuntu-latest-nx-build-native-<hash>` (our own namespace)
- `restore-keys:` → `ubuntu-latest-nx-build-native-<hash>` (falls back to main's canonical cache for reads)

So an unchanged-Java build still replays main's binary via the fallback, a branch's own repeat runs hit the `benchmark-` key, and main's cache is never touched. The save step already used `cache-primary-key`, so it picks up the new key automatically.

I'll add the `benchmark` label to this PR to exercise it. The *first* run still rebuilds (the `benchmark-` key doesn't exist yet and main currently has no ubuntu cache for this hash), but it'll save under the new key without disturbing anything on `main`.

- [ ] I've added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).
