### PR TITLE
Document benchmarking perf-affecting PRs via the label

### DIFF
--- a/.claude/rules/performance-harness.md
+++ b/.claude/rules/performance-harness.md
@@ -20,6 +20,16 @@ paths:
 Tooling to understand where time goes when formatting Apex, so optimizations are
 driven by numbers rather than guesses.
 
+## When to use it
+
+Any change that could plausibly affect formatting performance — the printer, the
+parser/prep DFS walk, comment attachment, or the Java `apex-ast-serializer` —
+should be measured, not just reasoned about. The simplest path is the CI
+workflow below: add the `benchmark` label to the PR and read the bot's
+comparison comment (`gh pr view <N> --json comments`). Treat a few-% delta as
+runner noise; act on consistent, sizeable shifts. Locally, `pnpm run benchmark`
+does the same against your working tree.
+
 ## Running it
 
 - `pnpm run benchmark` — interactive wizard (`tests_perf/setup.ts`). Picks the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ packages/
 
 - **Before pushing**: run `pnpm nx run prettier-plugin-apex:lint` and the unit tests (`pnpm nx run prettier-plugin-apex:test:parser --configuration built-in`). Both must pass.
 - **Changelog entry required for any change that affects formatted output.** Add a bullet under `# Unreleased` in `CHANGELOG.md`. Bug fixes, layout changes, comment-handling changes, and new grammar support all qualify. Pure test additions, build/CI tweaks, internal refactors, and dependency bumps don't.
+- **For changes that could affect performance** (printer, parser/prep walk, comment attachment, or the Java serializer), add the `benchmark` label to the PR and read the bot's comparison comment to confirm the real measured impact — don't reason about perf only in the abstract. See `performance-harness.md`.
 - **After completing a major feature**: verify CLAUDE.md and the relevant README files still accurately describe the project.
 
 ## Scoped rules


### PR DESCRIPTION
Small docs follow-up to #2410/#2413. Now that the benchmark CI exists, this writes down *when* to use it so it's not just tribal knowledge.

- `CLAUDE.md` (Universal workflow rules): a one-liner, parallel to the changelog rule — for changes that could affect performance (printer, parser/prep walk, comment attachment, or the Java serializer), add the `benchmark` label and read the bot's comparison comment to confirm the real measured impact.
- `.claude/rules/performance-harness.md`: a short "When to use it" section with the same guidance plus the `gh pr view <N> --json comments` mechanic and the "few-% = noise" caveat.

Docs only — no code or formatting changes.

- [ ] I've added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).
