### PR TITLE
Fix musl toolchain build on newer host GCC

### DIFF
--- a/packages/apex-ast-serializer/tools/build-musl-toolchain.sh
+++ b/packages/apex-ast-serializer/tools/build-musl-toolchain.sh
@@ -28,6 +28,13 @@ popd
 # Install a symlink for use by native-image
 ln -sf $MUSL_HOME/bin/musl-gcc $MUSL_HOME/bin/x86_64-linux-musl-gcc
 
+# GCC 14+ emits an internal "-latomic_asneeded" spec token that musl-gcc's -specs
+# override leaks straight through to ld ("cannot find -latomic_asneeded"), because it
+# bypasses the driver rewriting that would normally resolve it. x86_64 atomics are
+# inlined, so satisfy the token with an empty static archive -- a no-op at link time,
+# and an unused file on older GCC that never emits the token.
+ar rcs "$MUSL_HOME/lib/libatomic_asneeded.a"
+
 # Extend the system path and confirm that musl is available by printing its version
 export PATH="$MUSL_HOME/bin:$PATH"
 x86_64-linux-musl-gcc --version
@@ -35,8 +42,21 @@ x86_64-linux-musl-gcc --version
 # Build zlib with musl from source and install into the MUSL_HOME directory
 tar -xzvf zlib-${ZLIB_VERSION}.tar.gz
 pushd zlib-${ZLIB_VERSION}
-CC=musl-gcc ./configure --prefix=$MUSL_HOME --static
+# zlib's ./configure feature-probes rely on implicit function declarations, which
+# GCC 14+ promotes to hard errors -- so the probes false-negative and gzread.c
+# builds without <errno.h> (errno/EAGAIN/EWOULDBLOCK undeclared). These -Wno-* flags
+# restore the pre-GCC-14 probe behavior. The upstream source-level fix is unmerged
+# (tracking: madler/zlib#1168, candidate PRs #1196/#1022) and isn't in any release
+# yet -- 1.3.2, pinned above, still reproduces. Next time renovate bumps ZLIB_VERSION,
+# retest the native build without these flags and drop them if it's clean.
+CC=musl-gcc CFLAGS="-Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion" \
+  ./configure --prefix=$MUSL_HOME --static
 make && make install
 popd
+
+# Fail loudly if zlib mis-built and produced no static lib (e.g. a future toolchain
+# breaks the configure probes in a new way) instead of surfacing later as a confusing
+# native-image link error.
+test -f "$MUSL_HOME/lib/libz.a" || { echo "zlib build did not produce libz.a" >&2; exit 1; }
 
 rm -rf musl-${MUSL_VERSION}.tar.gz musl-${MUSL_VERSION} zlib-${ZLIB_VERSION}.tar.gz zlib-${ZLIB_VERSION}


### PR DESCRIPTION
Building the native binary locally on a rolling-release distro (Arch, GCC 16.1.1) fails because `tools/build-musl-toolchain.sh` builds musl + zlib against the host GCC, and a host compiler a few major versions newer than CI's breaks it in two independent ways. GCC 14+ promoted implicit function declarations and implicit-int from warnings to hard errors:

- **zlib won't compile.** Its old `configure` feature-probes lean on implicit declarations, so they now false-negative — `gzread.c` ends up built without `<errno.h>` (`errno`/`EAGAIN`/`EWOULDBLOCK` undeclared) and no `libz.a` is produced.
- **Every static link then fails** with `cannot find -latomic_asneeded`. Newer GCC emits that internal spec token, but `musl-gcc`'s `-specs` override bypasses the driver rewriting that would normally resolve it, so the literal token leaks to `ld`.

CI doesn't hit either because `ubuntu-latest` pins GCC 13, so this is a contributor-experience problem, not a release one. Fixes #2415.

This hardens the script so local native builds work on newer toolchains without manual fiddling, applied unconditionally (no host-GCC version guard — both fixes are no-ops on older GCC):

- **zlib:** pass `-Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion` to restore the pre-GCC-14 probe behavior. This targets the root cause (the configure mis-probe) rather than just the errno symptom, so feature detection — e.g. the `off64_t`/`_LARGEFILE64_SOURCE` probe — comes out correct again.
- **`-latomic_asneeded`:** drop an empty `libatomic_asneeded.a` into the toolchain. x86_64 atomics are inlined, so the stub satisfies the leaked token as a no-op. This is the established GraalVM-on-musl workaround.
- **Guard:** assert `libz.a` exists after the zlib build so a future toolchain that breaks the probes in a new way fails loudly instead of surfacing later as a confusing native-image link error.

The zlib `configure` fragility is unmerged upstream (tracking [madler/zlib#1168](https://github.com/madler/zlib/issues/1168), candidate PRs #1196/#1022) and isn't in any release yet — 1.3.2 (currently pinned) still reproduces. A comment in the script notes to retest without the flags the next time renovate bumps `ZLIB_VERSION`, and drop them if the build is clean.

## Testing

- Ran `./tools/build-musl-toolchain.sh` on the affected host (Arch, GCC 16.1.1) — clean build, zero compile errors, produced a 170K `libz.a`, and `_LARGEFILE64_SOURCE=1` was correctly detected (the probe that previously false-negatived).
- `pnpm nx run prettier-plugin-apex:lint` and `pnpm nx run prettier-plugin-apex:test:parser --configuration built-in` both pass.

## Checklist

- [ ] I’ve added tests to confirm my change works. <!-- N/A — toolchain build script; CI runs GCC 13 and can't exercise the newer-GCC path. Validated manually on GCC 16.1.1 (see Testing). -->
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file. <!-- N/A — build-script-only change, no formatted-output impact. -->
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).
