### PR TITLE
Fix benchmark native build failing on fork PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -145,9 +145,12 @@ jobs:
       - name: Build head native executable
         run: pnpm nx run apex-ast-serializer:build:native
         env:
-          # Withhold the Nx Cloud token from untrusted fork-PR code (pr input);
-          # trusted contexts (own branches, same-repo PRs) still get the cache.
-          NX_KEY: ${{ github.event.inputs.pr == '' && secrets.NX_KEY || '' }}
+          # This build caches via the GitHub Actions `.nx` cache restored above,
+          # not Nx Cloud — so disable Nx Cloud. A fork PR can't read secrets, so
+          # NX_KEY would be empty, and nx fails ("Failed to decode the Nx key")
+          # on a defined-but-empty key. Disabling cloud also keeps the token out
+          # of untrusted fork-PR code entirely.
+          NX_NO_CLOUD: "true"
 
       # Only cache a SUCCESSFUL build — saving after a failure would poison the
       # write-once cache key with an empty/partial .nx for the whole branch.


### PR DESCRIPTION
The benchmark workflow fails at "Build head native executable" for PRs from forks — e.g. [#2403](https://github.com/dangmai/prettier-plugin-apex/pull/2403) ([failing run](https://github.com/dangmai/prettier-plugin-apex/actions/runs/27836878101/job/82386857378)) with `NX  Failed to decode the Nx key`.

## Why

Fork PRs run on the `pull_request` event with **no access to secrets**, so `secrets.NX_KEY` is empty. The build step's `NX_KEY: ${{ ... && secrets.NX_KEY || '' }}` then sets `NX_KEY` to an empty **string** — and nx fails on a *defined-but-empty* key rather than treating it as absent. Same-repo PRs passed because they get the real secret.

## Fix

The benchmark's native build caches via the GitHub Actions `.nx` cache (restored in the prior step), not Nx Cloud — so just disable Nx Cloud (`NX_NO_CLOUD: true`) and drop the `NX_KEY` line. This:

- fixes fork PRs (nx never tries to decode a key),
- still keeps the Nx Cloud token out of untrusted fork code (the original intent of the conditional — now achieved more simply by not using the token at all), and
- doesn't regress same-repo caching, since the GitHub Actions cache is what the benchmark relies on.

Report-only workflow, no output impact.

- [ ] I've added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).
