### PR TITLE
Post benchmark comment via workflow_run so fork PRs work

### DIFF
--- a/.claude/rules/performance-harness.md
+++ b/.claude/rules/performance-harness.md
@@ -59,7 +59,16 @@ native-image build — while saving under a `benchmark-` prefixed key so it neve
 displaces main's canonical cache), downloads the
 latest scheduled `main` native artifact for the base side, benchmarks both
 back-to-back to cancel hardware variance, then renders `compare --markdown` into
-the job summary, a `benchmark-results` artifact, and a sticky PR comment.
+the job summary and a `benchmark-results` artifact.
+
+The sticky PR comment is posted by a **separate** `benchmark-comment.yml`
+(`workflow_run`), not by `benchmark.yml` itself. That's what lets it comment on
+**fork** PRs: the benchmark run gets a read-only token for fork code (it can't
+comment), so it uploads the report + PR number in the artifact, and the
+`workflow_run` job — which runs in the base repo with a write token and never
+touches fork code — downloads it and posts. Maintainer dispatches
+(`workflow_dispatch`, incl. `-f pr=<N>`) don't comment; their numbers live in
+the job summary + artifact only.
 
 The harness benchmarks whatever the plugin's **default** mode is (currently
 `native`) unless `--parser` overrides it, so the numbers reflect a zero-config

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,0 +1,59 @@
+name: Benchmark comment
+
+# Posts the benchmark comparison as a sticky PR comment. This is split out from
+# the Benchmark workflow so it can comment on FORK PRs: a `pull_request` run from
+# a fork gets a read-only token (it can't comment — "Resource not accessible by
+# integration"). This workflow instead runs via `workflow_run`, in the base
+# repo's context with a write token. Crucially it NEVER checks out or runs the
+# fork's code — it only downloads the inert results artifact and posts — so the
+# write token can't be abused by untrusted code. (This is the secure alternative
+# to pull_request_target, which would run fork code with elevated permissions.)
+
+on:
+  workflow_run:
+    workflows: ["Benchmark"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # download the artifact from the triggering run
+  pull-requests: write # post the comment
+
+jobs:
+  comment:
+    name: Post benchmark comment
+    # Only PR-triggered benchmark runs that produced results. Dispatches benchmark
+    # a branch (no PR to comment on) and failed runs have nothing to post.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark results from the triggering run
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: benchmark-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifact
+
+      # The PR number was written by the benchmark run (workflow_run.pull_requests
+      # is empty for forks). Validate it's a number before trusting it.
+      - name: Read PR number
+        id: meta
+        run: |
+          set -euo pipefail
+          pr=""
+          if [ -f artifact/pr-number.txt ]; then
+            pr=$(tr -dc '0-9' < artifact/pr-number.txt)
+          fi
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "PR number: ${pr:-<none>}"
+
+      - name: Post sticky comment
+        if: steps.meta.outputs.pr != '' && hashFiles('artifact/report.md') != ''
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
+        with:
+          number: ${{ steps.meta.outputs.pr }}
+          header: benchmark
+          path: artifact/report.md

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,11 +29,12 @@ on:
         required: false
         type: string
 
-# Read prior workflow artifacts (main's native build) and write a sticky comment.
+# Reads prior workflow artifacts (main's native build). Commenting is handled by
+# the separate benchmark-comment.yml (workflow_run) so it works for fork PRs too,
+# so this workflow — which runs untrusted fork code — needs no write scope.
 permissions:
   contents: read
   actions: read
-  pull-requests: write
 
 # A new push / dispatch supersedes an in-flight run for the same PR or branch.
 concurrency:
@@ -65,11 +66,9 @@ jobs:
           head_ref="$GH_REF"
           base_ref=""
           compare=false
-          comment=false
           if [ "$EVENT_NAME" = "pull_request" ]; then
             base_ref="$PR_BASE_REF"
             compare=true
-            comment=true
           elif [ -n "${PR_INPUT:-}" ]; then
             if ! printf '%s' "$PR_INPUT" | grep -Eq '^[0-9]+$'; then
               echo "::error::The 'pr' input must be a PR number."
@@ -88,9 +87,8 @@ jobs:
             echo "head_ref=$head_ref"
             echo "base_ref=$base_ref"
             echo "compare=$compare"
-            echo "comment=$comment"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved: head_ref=$head_ref base_ref=$base_ref compare=$compare comment=$comment"
+          echo "Resolved: head_ref=$head_ref base_ref=$base_ref compare=$compare"
 
       - name: Checkout head
         uses: actions/checkout@v6.0.3
@@ -244,19 +242,26 @@ jobs:
             report "$RUNNER_TEMP/head.json" \
             | tee "$RUNNER_TEMP/report.md" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload result JSON
+      # Record the PR number so the workflow_run comment job knows where to post.
+      # github.event.workflow_run.pull_requests is empty for fork PRs, so the
+      # number must travel via the artifact.
+      - name: Save PR number for the comment workflow
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > "$RUNNER_TEMP/pr-number.txt"
+
+      # The rendered report.md and pr-number.txt ride along so benchmark-comment.yml
+      # (workflow_run) can post the comment with a write token — which this
+      # fork-code-running workflow doesn't have.
+      - name: Upload benchmark results
         uses: actions/upload-artifact@v7.0.1
         with:
           name: benchmark-results
           path: |
             ${{ runner.temp }}/base.json
             ${{ runner.temp }}/head.json
+            ${{ runner.temp }}/report.md
+            ${{ runner.temp }}/pr-number.txt
           if-no-files-found: ignore
           retention-days: 30
-
-      - name: Post sticky PR comment
-        if: steps.setup.outputs.comment == 'true'
-        uses: marocchino/sticky-pull-request-comment@v3.0.4
-        with:
-          header: benchmark
-          path: ${{ runner.temp }}/report.md


### PR DESCRIPTION
Follow-up to the fork-PR benchmark work. With the native build now fixed (#2419), the benchmark on a fork PR like [#2403](https://github.com/dangmai/prettier-plugin-apex/pull/2403) runs all the way through and then fails only at the comment step: `Resource not accessible by integration`. That's GitHub's design — a `pull_request` run from a fork gets a **read-only** token, so it can't post a comment, regardless of the `permissions:` block.

## The fix: `workflow_run` two-stage commenting

This is GitHub's recommended secure pattern for commenting on fork PRs:

- **`benchmark.yml`** (unchanged behavior, now read-only): builds, benchmarks, renders the markdown, and uploads it in the `benchmark-results` artifact along with the PR number. It no longer comments, and **drops `pull-requests: write`** entirely.
- **`benchmark-comment.yml`** (new, `workflow_run`): triggers when a Benchmark run completes, runs in the **base repo** with a write token, downloads the artifact, and posts the sticky comment.

**Why it's safe:** the comment workflow runs from the default branch and **never checks out or runs the fork's code** — it only reads the inert artifact (report + PR number) and posts. So the write token can't be abused by untrusted code. This is the secure alternative to `pull_request_target` (which would run fork code with elevated perms — what we want to avoid).

Notes:
- The PR number travels via the artifact because `github.event.workflow_run.pull_requests` is empty for fork PRs.
- The comment job is gated to `workflow_run.event == 'pull_request'` and `conclusion == 'success'`, so maintainer dispatches (`-f pr=<N>`) and failed runs don't try to comment.
- `workflow_run` workflows only take effect once on the default branch, so commenting starts working after this merges.

Report-only, no formatting impact.

- [ ] I've added tests to confirm my change works.
- [ ] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).
