### PR TITLE
Clarify the benchmark comment gating comment

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -22,8 +22,8 @@ permissions:
 jobs:
   comment:
     name: Post benchmark comment
-    # Only PR-triggered benchmark runs that produced results. Dispatches benchmark
-    # a branch (no PR to comment on) and failed runs have nothing to post.
+    # Only PR-triggered benchmark runs that produced results. Dispatched runs
+    # benchmark a branch (no PR to comment on) and failed runs have nothing to post.
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'


### PR DESCRIPTION
Tiny wording fix to a comment in benchmark-comment.yml (reviewer nit from #2420). No behavior change. Also serving as a same-repo test of the new workflow_run comment loop.