### PR TITLE
Support the SOQL WITH tuple/key-value form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix trailing empty line not printed after ignored nodes in class declaration blocks ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/1892)).
 - Fix standalone comments before SOQL `WITH SECURITY_ENFORCED` / `WITH USER_MODE` / `WITH SYSTEM_MODE` clauses migrating between `WITH` and the identifier across format passes.
 - Fix trailing comments on the last field of a SOSL `RETURNING X(...)` clause migrating outside the closing paren across format passes.
+- Support the SOQL `WITH` tuple/key-value form (`WITH Identifier(key = value, ...)`), which previously threw `No handler found` ([issue](https://github.com/dangmai/prettier-plugin-apex/issues/2423)).
 
 ## Dependency Changes
 

--- a/packages/prettier-plugin-apex/src/constants.ts
+++ b/packages/prettier-plugin-apex/src/constants.ts
@@ -319,6 +319,18 @@ export const APEX_TYPES = {
   DATA_CATEGORY_OPERATOR: "apex.jorje.data.soql.DataCategoryOperator" as const,
   WITH_IDENTIFIER:
     "apex.jorje.data.soql.WithIdentifierClause$WithIdentifier" as const,
+  WITH_IDENTIFIER_TUPLE:
+    "apex.jorje.data.soql.WithIdentifierClause$WithIdentifierTuple" as const,
+  WITH_KEY_VALUE: "apex.jorje.data.soql.WithKeyValue" as const,
+  // The subtype @class strings must stay catalogued here so that PARENT_TYPES
+  // (built from Object.values(APEX_TYPES)) maps each one back to WITH_KEY_VALUE,
+  // which is what lets genericPrint's parent fallback dispatch them.
+  WITH_KEY_VALUE_BOOLEAN:
+    "apex.jorje.data.soql.WithKeyValue$BooleanKeyValue" as const,
+  WITH_KEY_VALUE_NUMBER:
+    "apex.jorje.data.soql.WithKeyValue$NumberKeyValue" as const,
+  WITH_KEY_VALUE_STRING:
+    "apex.jorje.data.soql.WithKeyValue$StringKeyValue" as const,
 };
 export const BINARY = {
   ADDITION: "+" as const,

--- a/packages/prettier-plugin-apex/src/printer.ts
+++ b/packages/prettier-plugin-apex/src/printer.ts
@@ -2422,6 +2422,42 @@ function handleWithValue(path: AstPath, print: PrintFn): Doc {
   return parts;
 }
 
+function handleWithIdentifierTuple(path: AstPath, print: PrintFn): Doc {
+  const keyValueDocs: Doc[] = path.map(print, "keyValues");
+  return groupIndentConcat([
+    "WITH",
+    " ",
+    path.call(print, "identifier"),
+    "(",
+    softline,
+    join([",", line], keyValueDocs),
+    dedent(softline),
+    ")",
+  ]);
+}
+
+function handleWithKeyValue(
+  childClass: string,
+  path: AstPath,
+  print: PrintFn,
+): Doc {
+  const parts: Doc[] = [];
+  parts.push(path.call(print, "identifier"));
+  parts.push(" ");
+  parts.push("=");
+  parts.push(" ");
+  if (childClass === APEX_TYPES.WITH_KEY_VALUE_STRING) {
+    // The string value is stored unquoted, so we re-add the single quotes.
+    parts.push("'");
+    parts.push(path.call(print, "value"));
+    parts.push("'");
+  } else {
+    // Boolean and number values print themselves verbatim.
+    parts.push(path.call(print, "value"));
+  }
+  return parts;
+}
+
 function handleWithDataCategories(path: AstPath, print: PrintFn): Doc {
   const categoryDocs: Doc[] = path.map(print, "categories");
 
@@ -3270,6 +3306,8 @@ const nodeHandler: { [key: string]: ChildNodeHandler | SingleNodeHandler } = {
     " ",
     path.call(print, "identifier"),
   ],
+  [APEX_TYPES.WITH_IDENTIFIER_TUPLE]: handleWithIdentifierTuple,
+  [APEX_TYPES.WITH_KEY_VALUE]: handleWithKeyValue,
 };
 
 function handleTrailingEmptyLines(doc: Doc, node: any): Doc {

--- a/packages/prettier-plugin-apex/tests/soql_with_tuple/SOQLWithTuple.cls
+++ b/packages/prettier-plugin-apex/tests/soql_with_tuple/SOQLWithTuple.cls
@@ -1,0 +1,37 @@
+class SOQLWithTuple {
+  void keyValueTypes() {
+    Account[] numberValue = [SELECT Id FROM Account WITH Foo(bar = 1)];
+    Account[] stringValue = [SELECT Id FROM Account WITH Foo(bar = 'baz')];
+    Account[] booleanValue = [SELECT Id FROM Account WITH Foo(bar = true)];
+  }
+
+  void multipleKeyValues() {
+    Account[] mixed = [SELECT Id FROM Account WITH Foo(bar = 1, baz = 'qux', flag = true)];
+  }
+
+  void caseAndSpacing() {
+    Account[] lower = [SELECT Id FROM Account with Foo(bar=1)];
+    Account[] extraSpaces = [SELECT Id FROM Account WITH    Foo(  bar   =   1  )];
+  }
+
+  void withOtherClauses() {
+    Account[] whereAndTuple = [SELECT Id FROM Account WHERE Name = 'Acme' WITH Foo(bar = 1)];
+    Account[] tupleThenOrder = [SELECT Id FROM Account WITH Foo(bar = 1) ORDER BY Name LIMIT 10];
+  }
+
+  void combinedWithIdentifiers() {
+    Account[] tupleThenIdentifier = [SELECT Id FROM Account WITH Foo(bar = 1) WITH USER_MODE];
+  }
+
+  void longLineForcesWrapping() {
+    Account[] longQuery = [SELECT Id, Name FROM Account WITH MetadataFilter(longKeyNameOne = 'valueOne', longKeyNameTwo = 'valueTwo', longKeyNameThree = 12345, longKeyNameFour = true)];
+  }
+
+  void multilineBody() {
+    Account[] verbose = [
+      SELECT Id
+      FROM Account
+      WITH Foo(bar = 1, baz = 'qux')
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_with_tuple/SOQLWithTuple.cls
+++ b/packages/prettier-plugin-apex/tests/soql_with_tuple/SOQLWithTuple.cls
@@ -9,6 +9,11 @@ class SOQLWithTuple {
     Account[] mixed = [SELECT Id FROM Account WITH Foo(bar = 1, baz = 'qux', flag = true)];
   }
 
+  void stringEscaping() {
+    Account[] embeddedQuote = [SELECT Id FROM Account WITH Foo(bar = 'a\'b')];
+    Account[] backslash = [SELECT Id FROM Account WITH Foo(bar = 'a\\b')];
+  }
+
   void caseAndSpacing() {
     Account[] lower = [SELECT Id FROM Account with Foo(bar=1)];
     Account[] extraSpaces = [SELECT Id FROM Account WITH    Foo(  bar   =   1  )];

--- a/packages/prettier-plugin-apex/tests/soql_with_tuple/__snapshots__/FormattedSOQLWithTuple1.cls
+++ b/packages/prettier-plugin-apex/tests/soql_with_tuple/__snapshots__/FormattedSOQLWithTuple1.cls
@@ -13,6 +13,11 @@ class SOQLWithTuple {
     ];
   }
 
+  void stringEscaping() {
+    Account[] embeddedQuote = [SELECT Id FROM Account WITH Foo(bar = 'a\'b')];
+    Account[] backslash = [SELECT Id FROM Account WITH Foo(bar = 'a\\b')];
+  }
+
   void caseAndSpacing() {
     Account[] lower = [SELECT Id FROM Account WITH Foo(bar = 1)];
     Account[] extraSpaces = [SELECT Id FROM Account WITH Foo(bar = 1)];

--- a/packages/prettier-plugin-apex/tests/soql_with_tuple/__snapshots__/FormattedSOQLWithTuple1.cls
+++ b/packages/prettier-plugin-apex/tests/soql_with_tuple/__snapshots__/FormattedSOQLWithTuple1.cls
@@ -1,0 +1,65 @@
+class SOQLWithTuple {
+  void keyValueTypes() {
+    Account[] numberValue = [SELECT Id FROM Account WITH Foo(bar = 1)];
+    Account[] stringValue = [SELECT Id FROM Account WITH Foo(bar = 'baz')];
+    Account[] booleanValue = [SELECT Id FROM Account WITH Foo(bar = true)];
+  }
+
+  void multipleKeyValues() {
+    Account[] mixed = [
+      SELECT Id
+      FROM Account
+      WITH Foo(bar = 1, baz = 'qux', flag = true)
+    ];
+  }
+
+  void caseAndSpacing() {
+    Account[] lower = [SELECT Id FROM Account WITH Foo(bar = 1)];
+    Account[] extraSpaces = [SELECT Id FROM Account WITH Foo(bar = 1)];
+  }
+
+  void withOtherClauses() {
+    Account[] whereAndTuple = [
+      SELECT Id
+      FROM Account
+      WHERE Name = 'Acme'
+      WITH Foo(bar = 1)
+    ];
+    Account[] tupleThenOrder = [
+      SELECT Id
+      FROM Account
+      WITH Foo(bar = 1)
+      ORDER BY Name
+      LIMIT 10
+    ];
+  }
+
+  void combinedWithIdentifiers() {
+    Account[] tupleThenIdentifier = [
+      SELECT Id
+      FROM Account
+      WITH Foo(bar = 1) WITH USER_MODE
+    ];
+  }
+
+  void longLineForcesWrapping() {
+    Account[] longQuery = [
+      SELECT Id, Name
+      FROM Account
+      WITH MetadataFilter(
+        longKeyNameOne = 'valueOne',
+        longKeyNameTwo = 'valueTwo',
+        longKeyNameThree = 12345,
+        longKeyNameFour = true
+      )
+    ];
+  }
+
+  void multilineBody() {
+    Account[] verbose = [
+      SELECT Id
+      FROM Account
+      WITH Foo(bar = 1, baz = 'qux')
+    ];
+  }
+}

--- a/packages/prettier-plugin-apex/tests/soql_with_tuple/jsfmt.spec.ts
+++ b/packages/prettier-plugin-apex/tests/soql_with_tuple/jsfmt.spec.ts
@@ -1,0 +1,3 @@
+import { fileURLToPath } from "url";
+
+runSpec(fileURLToPath(new URL(".", import.meta.url)), ["apex"]);


### PR DESCRIPTION
The SOQL `WITH` *tuple* form — `WITH Identifier(key = value, ...)` — is reachable in the jorje AST but had no handler in `printer.ts`. Neither `WithIdentifierClause$WithIdentifierTuple` nor the `WithKeyValue$Boolean/Number/String` subtypes were dispatched, so formatting any query using the tuple form hit the `No handler found … Please file a bug report` throw. This is pre-existing and latent (no fixture exercised it); it was surfaced by the dispatch-exhaustiveness test added in #2422, and filed as #2423.

The simpler `WITH <identifier> = <value>` form and `WITH DATA CATEGORY` were already handled — only the tuple/key-value variant was missing.

Changes:

- Add `handleWithIdentifierTuple` (`WITH ident(...)`, with a group so long key-value lists wrap) and `handleWithKeyValue` to `printer.ts`.
- Catalog the new `@class` strings in `APEX_TYPES`. The `WithKeyValue$*` subtypes are dispatched through the parent-class fallback, which is driven by `PARENT_TYPES` (built from `Object.values(APEX_TYPES)`), so each subtype constant has to be listed even though only the string case is referenced by name in the handler.
- String key-values are stored unquoted by jorje, so the handler re-adds the single quotes; booleans and numbers print verbatim.
- Add a `tests/soql_with_tuple/` fixture covering each value type, multiple key-values, spacing/case normalization, combination with other clauses, and long-line wrapping (TDD: it failed with the throw before the fix).

Follow-up: once #2422 lands, its `UNHANDLED_CLASSES` denylist in `tests/dispatch_exhaustiveness/dispatch.spec.ts` should drop these four `@class` entries so the exhaustiveness test enforces the coverage. That cleanup lives on the `strict-typescript` branch, not here.

Closes #2423

- [x] I've added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I've read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).