### PR TITLE
Document pre-merge integration tests and internal-change changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ packages/
 ## Universal workflow rules
 
 - **Before pushing**: run `pnpm nx run prettier-plugin-apex:lint` and the unit tests (`pnpm nx run prettier-plugin-apex:test:parser --configuration built-in`). Both must pass.
-- **Changelog entry required for any change that affects formatted output.** Add a bullet under `# Unreleased` in `CHANGELOG.md`. Bug fixes, layout changes, comment-handling changes, and new grammar support all qualify. Pure test additions, build/CI tweaks, internal refactors, and dependency bumps don't.
+- **Before merging a non-trivial PR**: the integration suite runs only on manual dispatch (`gh workflow run tests-deployments.yml --ref <branch>`), not regular PR CI — dispatch it and confirm green first.
+- **Changelog entry required for any change that affects formatted output.** Add a bullet under `# Unreleased` in `CHANGELOG.md`. Bug fixes, layout changes, comment-handling changes, and new grammar support all qualify. Pure test additions, build/CI tweaks, internal refactors, and dependency bumps don't — though a notable internal-only improvement (e.g. a type-safety pass) still warrants a one-line `## Internal Changes` bullet.
 - **For changes that could affect performance** (printer, parser/prep walk, comment attachment, or the Java serializer), add the `benchmark` label to the PR and read the bot's comparison comment to confirm the real measured impact — don't reason about perf only in the abstract. See `performance-harness.md`.
 - **After completing a major feature**: verify CLAUDE.md and the relevant README files still accurately describe the project.
 - **Big feature work needs an ADR** in `adr/` at the repo root, recording the decision and its rationale.


### PR DESCRIPTION
Two workflow rules surfaced while shipping the strict-TypeScript migration (#2422):

- The integration suite only runs on manual `workflow_dispatch` (regular PR CI skips it), so it should be dispatched and confirmed green before merging a non-trivial PR.
- A notable internal-only improvement (e.g. a type-safety pass) is worth a one-line `## Internal Changes` changelog bullet, even though pure internal refactors don't otherwise require one.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)