### PR TITLE
Highlight JSONC config files correctly on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,16 @@ packages/prettier-plugin-apex/vendor/apex-ast-serializer/bin/apex-ast-serializer
 .gitattributes text eol=lf
 gradlew text eol=lf
 
+# Linguist language overrides
+#
+# These files are actually JSONC (they contain `//` comments). Without an
+# override GitHub highlights them as plain JSON, so the comment lines render as
+# syntax errors. Tell Linguist to treat them as "JSON with Comments" so they
+# highlight correctly on GitHub. Linguist already auto-detects tsconfig.json and
+# devcontainer.json by name, so only the non-standard names need a hint here.
+renovate.json linguist-language=JSON-with-Comments
+packages/prettier-plugin-apex/tsconfig.prod.json linguist-language=JSON-with-Comments
+
 # Windows specific files
 *.bat text eol=crlf
 


### PR DESCRIPTION
`renovate.json` and `packages/prettier-plugin-apex/tsconfig.prod.json` are actually JSONC — they contain `//` comments — but neither name is in [Linguist's](https://github.com/github-linguist/linguist) auto-detected `JSON with Comments` list. So GitHub renders them as plain JSON and the comment lines show up as syntax errors.

This adds `linguist-language=JSON-with-Comments` overrides for those two files, mirroring the same fix in my dotfiles repo.

I checked the other JSONC-ish files in the repo: `tsconfig.json`, `packages/*/tsconfig.json`, and `.devcontainer/devcontainer.json` are all already auto-detected by Linguist by filename, so they don't need an override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzNvdexmBa8xFHqJcsYPWQ