### PR TITLE
Grant contents:write to release job for GitHub Release

### DIFF
--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -254,6 +254,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Release to Registry
     if: startsWith(github.ref, 'refs/tags')
+    permissions:
+      # Required for NPM Trusted Publishing OIDC
+      id-token: write
+      # Required for softprops/action-gh-release to create the GitHub Release
+      contents: write
     needs:
       - functional-tests
       - build-native-executables


### PR DESCRIPTION
The v2.3.0 release [workflow run](https://github.com/dangmai/prettier-plugin-apex/actions/runs/27996934331) failed on the **Create GitHub Release** step with a `403 Resource not accessible by integration`. The npm publish still succeeded (it authenticates via OIDC / `id-token`), so the package made it to npmjs — but no GitHub Release got created for the tag.

The root cause is permission scoping. The workflow-level `permissions:` block only sets `id-token: write` (for npm Trusted Publishing). In GitHub Actions, as soon as you set *any* permission explicitly, every unspecified scope defaults to `none` — so `contents` was `none`, and `softprops/action-gh-release` can't create a release without `contents: write`.

The fix adds a job-level `permissions:` block to `release-to-registry`:

- `contents: write` so the GitHub Release can be created
- `id-token: write` re-granted, because a job-level block *replaces* the inherited workflow-level set rather than merging — without it the npm OIDC publish in the same job would lose its token

I scoped this to the release job rather than widening the top-level block, to keep the other jobs (tests, native builds) at least privilege.

This wasn't blocking — 2.3.0 is already on npm — but it'd be nice to have GitHub Releases tagged again before the next release.