### PR TITLE
Add scheduled CI job testing against latest Prettier

### DIFF
--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -124,6 +124,70 @@ jobs:
         if: env.RUN_INTEGRATION_TESTS == 'true'
         run: ./packages/prettier-plugin-apex/tests_integration/format/run-integration-tests.sh
 
+  # Canary that runs the full snapshot suite against the latest published
+  # Prettier, rather than the version pinned in the lockfile. Prettier's
+  # internals (comment attachment, doc printing) can change our formatted
+  # output without any change on our side - see the 3.9.0 `comment.placement`
+  # regression. The regular functional-tests job only ever sees the locked
+  # Prettier, so such breaks otherwise only surface when Renovate bumps the
+  # lockfile. Scheduled/dispatch only, to keep PR CI fast.
+  functional-tests-prettier-latest:
+    name: Run functional tests on latest Prettier
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - uses: actions/setup-java@v5.5.0
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      # See the functional-tests job for why this is needed.
+      - name: Remove ipv6 loopback
+        run: sudo sed -Ei '/(^::1)/d' /etc/hosts
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Force the whole workspace onto the latest published Prettier. The
+      # plugin's `prettier` peer otherwise stays resolved to the locked
+      # version, so overriding it is the only way the suite actually exercises
+      # the new Prettier. pnpm 11 reads `overrides` from pnpm-workspace.yaml.
+      - name: Override Prettier to latest
+        run: |
+          LATEST=$(npm view prettier version)
+          echo "Testing against prettier@$LATEST"
+          printf '\noverrides:\n  prettier: "%s"\n' "$LATEST" >> pnpm-workspace.yaml
+          pnpm install --no-frozen-lockfile
+          pnpm why prettier
+
+      # Build the Java serializer up front so the vendored binary exists before
+      # the server launches, rather than letting start-server build it in the
+      # background where a slow build races wait-server.
+      - name: Build Apex AST Serializer
+        run: pnpm nx run apex-ast-serializer:build
+
+      - name: Run Apex parsing server
+        run: pnpm nx run prettier-plugin-apex:start-server &
+
+      - name: Wait for Apex parsing server to be up
+        run: pnpm nx run prettier-plugin-apex:wait-server
+
+      - name: Run functional tests
+        run: AST_COMPARE=true pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
+
   package-tests:
     name: Test latest Prettier Apex package
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Internal Changes
+
+- Add a scheduled CI job that runs the formatting snapshot suite against the latest published Prettier, so upstream Prettier changes that alter our output are caught on their own rather than only when a lockfile bump happens to surface them.
+
 # 2.3.0
 
 ## Formatting Changes


### PR DESCRIPTION
## Why

Prettier's internals (comment attachment, doc printing) can change the plugin's formatted output with no change on our side. The 3.9.0 `comment.placement` regression (prettier/prettier#19515, fixed in #19521) is the motivating case: it broke our output, but our CI stayed green until Renovate bumped the lockfile — at which point it looked like a lockfile problem rather than a Prettier one.

The `functional-tests` job only ever installs the Prettier version pinned in the lockfile, so this class of break is invisible to normal PR CI and only surfaces reactively.

## What

A new `functional-tests-prettier-latest` job that:

- Runs on `schedule` + `workflow_dispatch` only (keeps PR CI fast — Prettier bumps arrive via Renovate PRs where the frozen install already exercises the new version).
- Overrides the whole workspace onto the latest published Prettier, then runs the full `AST_COMPARE=true … test:parser` snapshot suite against it.

### Notes

- **Why an override, not just `pnpm add`:** the plugin's `prettier` peer stays resolved to the locked version otherwise. pnpm 11 reads `overrides` from `pnpm-workspace.yaml` (not `package.json`), so the job appends the override there and reinstalls. Verified locally that this actually re-resolves the plugin's peer.
- **Why the explicit serializer build:** the suite needs the parser server, whose vendored binary comes from `apex-ast-serializer:build`. Building it up front avoids `start-server` racing `wait-server` with a slow background Gradle build.
- **Relationship to `package-tests`:** that job stays as-is — it smoke-tests the published tarball across OSes with `--debug-check`, which can't catch comment-placement drift (the 3.9 output was idempotent and AST-equivalent; only the snapshot comparison caught it). This job is the snapshot-drift detector.

Validated the full sequence locally (override → install → build serializer → start server → suite): 287/287 pass on the current latest Prettier.