### PR TITLE
Force prettier peer to track the root devDependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prettier: 3.9.5
+
 importers:
 
   .:
@@ -108,7 +111,7 @@ importers:
         specifier: ^30.0.0
         version: 30.4.0
       prettier:
-        specifier: ^3.0.0
+        specifier: 3.9.5
         version: 3.9.5
       wait-on:
         specifier: ^9.0.0
@@ -1743,12 +1746,12 @@ packages:
   prettier-plugin-java@2.10.2:
     resolution: {integrity: sha512-oOXUBqb0BKfL//ZeYFcsRtbm4h8jdicg1axbBrXh2tnUcAcKAyFCl3gUL7bN7kwDwFRraQop1RF9BZk+K6pmoQ==}
     peerDependencies:
-      prettier: ^3.0.0
+      prettier: 3.9.5
 
   prettier-plugin-organize-imports@4.3.0:
     resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
     peerDependencies:
-      prettier: '>=2.0'
+      prettier: 3.9.5
       typescript: '>=2.9'
       vue-tsc: ^2.1.0 || 3
     peerDependenciesMeta:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,11 @@ packages:
 allowBuilds:
   esbuild: true
   nx: true
+
+# Force every prettier in the graph - including the plugin's `prettier` peer -
+# to the exact version pinned in the root devDependencies. Without this the peer
+# resolves independently and can lag the devDep, so a Renovate prettier bump
+# would not actually be exercised by the test suite (see the 3.9.0
+# comment.placement regression, which merged green for exactly this reason).
+overrides:
+  prettier: "$prettier"


### PR DESCRIPTION
## Why

We want a Prettier upstream change that alters our formatted output to fail CI at the moment Renovate bumps Prettier — not silently, and not only via a scheduled canary.

The blocker: the plugin's `prettier` **peer** resolves independently of the root devDependency and can lag behind it. The test suite imports Prettier through the plugin's resolution, so a Renovate bump of the exact `prettier` devDep is not necessarily exercised at all.

That's not hypothetical — it's exactly what happened with the 3.9.0 `comment.placement` regression:

- `3073330f "Update dependency prettier to v3.9.1"` (a Renovate exact-devDep bump) merged **green** while the bug was live, because the plugin's peer stayed resolved to a leftover 3.8.3.
- The break only surfaced later, via a lockfile-maintenance PR that happened to dedupe the peer onto 3.9.1.

## What

Add a pnpm override in `pnpm-workspace.yaml`:

```yaml
overrides:
  prettier: "$prettier"
```

`$prettier` forces every `prettier` in the graph — including the plugin's peer — to the exact version in the root `devDependencies`. Verified locally: pinning the devDep to an older version moves the plugin's peer to match, and the tree deduplicates to a single version.

Result:

- Renovate keeps bumping the exact `prettier` devDep (unchanged).
- The override auto-follows it (nothing extra to maintain).
- The bump PR's `functional-tests` suite now runs against the new Prettier for real, so this class of regression turns CI red at bump time.

## Notes

- **No new infrastructure** — supersedes the earlier ideas of a scheduled canary job and extending `package-tests`.
- **Zero consumer impact** — `overrides` only affects this repo's dev/CI install; the published `peerDependencies: ^3.0.0` is untouched.
- Keeps the tree permanently deduped, so the "leftover old Prettier" situation that started this can't recur.
- Resolution-neutral right now (Prettier stays 3.9.5); the lockfile change is just the recorded override.