### PR TITLE
ci: don't run maintainer-only workflows on forks

### DIFF
--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   changes:
+    if: github.repository == 'dangmai/prettier-plugin-apex'
     runs-on: ubuntu-latest
     outputs:
       musl-script: ${{ steps.filter.outputs.musl-script }}
@@ -27,6 +28,7 @@ jobs:
               - 'packages/apex-ast-serializer/tools/build-musl-toolchain.sh'
 
   functional-tests:
+    if: github.repository == 'dangmai/prettier-plugin-apex'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -126,7 +128,7 @@ jobs:
 
   package-tests:
     name: Test latest Prettier Apex package
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'dangmai/prettier-plugin-apex'
     strategy:
       matrix:
         os:
@@ -157,7 +159,7 @@ jobs:
   build-native-executables:
     name: Build Native Executables
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags') || needs.changes.outputs.musl-script == 'true'
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags') || needs.changes.outputs.musl-script == 'true') && github.repository == 'dangmai/prettier-plugin-apex'
     strategy:
       matrix:
         os:
@@ -253,7 +255,7 @@ jobs:
   release-to-registry:
     runs-on: ubuntu-latest
     name: Release to Registry
-    if: startsWith(github.ref, 'refs/tags')
+    if: startsWith(github.ref, 'refs/tags') && github.repository == 'dangmai/prettier-plugin-apex'
     permissions:
       # Required for NPM Trusted Publishing OIDC
       id-token: write

--- a/.github/workflows/update-jorje.yml
+++ b/.github/workflows/update-jorje.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   jorje:
+    if: github.repository == 'dangmai/prettier-plugin-apex'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/warm-hosted-service.yml
+++ b/.github/workflows/warm-hosted-service.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   warm-hosted-service:
+    if: github.repository == 'dangmai/prettier-plugin-apex'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Guard schedule/deploy jobs with `github.repository == 'dangmai/prettier-plugin-apex'` so forks don't run (and fail) them. CodeQL left as-is.