### PR TITLE
Skip secret-dependent CI steps on forks instead of failing

### DIFF
--- a/.github/actions/resolve-secret/action.yml
+++ b/.github/actions/resolve-secret/action.yml
@@ -62,7 +62,16 @@ runs:
         # Case 2: the workflow is running on a fork's own actions (push /
         # schedule / dispatch). Query fork status at runtime rather than reading
         # github.event.repository.fork, which is absent on schedule events.
-        is_fork=$(gh api "repos/$REPO" --jq '.fork' 2>/dev/null || echo "unknown")
+        # Retry a few times so a transient API hiccup doesn't wrongly fail a
+        # fork here (this is the only signal we have for a fork's own runs).
+        is_fork="unknown"
+        for attempt in 1 2 3; do
+          if is_fork=$(gh api "repos/$REPO" --jq '.fork' 2>/dev/null); then
+            break
+          fi
+          is_fork="unknown"
+          if [ "$attempt" -lt 3 ]; then sleep 3; fi
+        done
         if [ "$is_fork" = "true" ]; then
           skip
         fi

--- a/.github/actions/resolve-secret/action.yml
+++ b/.github/actions/resolve-secret/action.yml
@@ -1,0 +1,74 @@
+name: Resolve secret
+description: >-
+  Decide whether a repository secret is usable for a step. On the canonical
+  repository (no upstream) a missing secret is a hard error, because the
+  maintainer expects it to be configured. On a fork it's a convenience skip:
+  contributors don't have the maintainer's secrets, so the dependent step is
+  simply left out with a warning annotation instead of failing their CI.
+
+inputs:
+  name:
+    description: Human-readable name of the secret, used in log annotations.
+    required: true
+  value:
+    description: The secret value, e.g. ${{ secrets.MY_TOKEN }}.
+    required: true
+  github-token:
+    description: Token used to query the repository's fork status.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  available:
+    description: '"true" when the secret is set and the dependent step should run.'
+    value: ${{ steps.resolve.outputs.available }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        SECRET_NAME: ${{ inputs.name }}
+        SECRET_VALUE: ${{ inputs.value }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        # For a pull_request from a fork this is the fork's full name, which
+        # differs from REPO (the base repo the run executes in). Empty for
+        # non-PR events and same-repo PRs.
+        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      run: |
+        set -euo pipefail
+
+        # Fast path: secret is present, no need to look any further.
+        if [ -n "$SECRET_VALUE" ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        skip() {
+          echo "::warning title=$SECRET_NAME not set::$SECRET_NAME is not available here; skipping the step that needs it. This is expected for contributor forks and does not fail the build."
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        }
+
+        # Case 1: a pull_request opened from a fork. GitHub withholds secrets
+        # from such runs even though they execute in the base repo's context
+        # (REPO is canonical, fork=false), so key off the PR's head repo.
+        if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$REPO" ]; then
+          skip
+        fi
+
+        # Case 2: the workflow is running on a fork's own actions (push /
+        # schedule / dispatch). Query fork status at runtime rather than reading
+        # github.event.repository.fork, which is absent on schedule events.
+        is_fork=$(gh api "repos/$REPO" --jq '.fork' 2>/dev/null || echo "unknown")
+        if [ "$is_fork" = "true" ]; then
+          skip
+        fi
+
+        # Otherwise this is the canonical repo's own trusted run with a genuinely
+        # missing secret (or a fork we couldn't confirm): fail loudly so a
+        # dropped/renamed secret is noticed instead of silently skipped.
+        echo "::error title=$SECRET_NAME not set::$SECRET_NAME is required on this repository but is not set (fork status: $is_fork)."
+        exit 1

--- a/.github/actions/resolve-secret/action.yml
+++ b/.github/actions/resolve-secret/action.yml
@@ -11,12 +11,8 @@ inputs:
     description: Human-readable name of the secret, used in log annotations.
     required: true
   value:
-    description: The secret value, e.g. ${{ secrets.MY_TOKEN }}.
+    description: The secret value to check, e.g. pass secrets.MY_TOKEN here.
     required: true
-  github-token:
-    description: Token used to query the repository's fork status.
-    required: false
-    default: ${{ github.token }}
 
 outputs:
   available:
@@ -31,7 +27,7 @@ runs:
       env:
         SECRET_NAME: ${{ inputs.name }}
         SECRET_VALUE: ${{ inputs.value }}
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
         # For a pull_request from a fork this is the fork's full name, which
         # differs from REPO (the base repo the run executes in). Empty for

--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -82,8 +82,19 @@ jobs:
       - name: Test Apex AST Serializer
         run: pnpm nx run apex-ast-serializer:test
 
-      - name: Upload Apex AST Serializer code coverage
+      # Codecov upload needs CODECOV_TOKEN. It's absent on contributor forks,
+      # so resolve once: fail on the canonical repo, skip (with a warning) on a
+      # fork. Both upload steps below gate on the resolved availability.
+      - name: Resolve Codecov token
+        id: codecov_secret
         if: matrix.ENABLE_CODE_COVERAGE
+        uses: ./.github/actions/resolve-secret
+        with:
+          name: CODECOV_TOKEN
+          value: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Apex AST Serializer code coverage
+        if: matrix.ENABLE_CODE_COVERAGE && steps.codecov_secret.outputs.available == 'true'
         uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -101,7 +112,7 @@ jobs:
         run: AST_COMPARE=true pnpm nx run prettier-plugin-apex:test:parser --configuration built-in
 
       - name: Upload Prettier Plugin Apex code coverage
-        if: matrix.ENABLE_CODE_COVERAGE
+        if: matrix.ENABLE_CODE_COVERAGE && steps.codecov_secret.outputs.available == 'true'
         uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -190,13 +201,21 @@ jobs:
       ARTIFACT_NAME: ${{ matrix.ARTIFACT_NAME }}
       UPLOAD_ARTIFACTS: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags') }}
       OS: ${{ matrix.os }}
-      NX_KEY: ${{ secrets.NX_KEY }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: ./packages/apex-ast-serializer
     steps:
       - uses: actions/checkout@v7
+      # NX_KEY enables Nx Cloud distributed caching. It's absent on contributor
+      # forks, so resolve it: fail on the canonical repo (a dropped key should
+      # be loud), and on a fork fall back to a cloud-less build below.
+      - name: Resolve Nx Cloud key
+        id: nx_secret
+        uses: ./.github/actions/resolve-secret
+        with:
+          name: NX_KEY
+          value: ${{ secrets.NX_KEY }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.9
       - name: Setup Node.js
@@ -231,6 +250,10 @@ jobs:
           # problem when different drives are used, such as in GHA runners.
           # https://github.com/graalvm/native-build-tools/issues/754
           GRADLE_OPTS: -Djava.io.tmpdir=${{ runner.temp }}
+          # With the key present, use Nx Cloud. Without it (fork), disable cloud
+          # so nx doesn't try to decode a missing/empty key and fail.
+          NX_KEY: ${{ steps.nx_secret.outputs.available == 'true' && secrets.NX_KEY || '' }}
+          NX_NO_CLOUD: ${{ steps.nx_secret.outputs.available == 'true' && 'false' || 'true' }}
       - name: Sanity check native executable
         shell: bash
         run: |

--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -243,6 +243,9 @@ jobs:
       - name: Build Linux musl toolchain
         if: matrix.os == 'ubuntu-latest'
         run: pnpm nx run apex-ast-serializer:build:musl
+        env:
+          NX_KEY: ${{ steps.nx_secret.outputs.available == 'true' && secrets.NX_KEY || '' }}
+          NX_NO_CLOUD: ${{ steps.nx_secret.outputs.available == 'true' && 'false' || 'true' }}
       - name: Build native executable
         run: pnpm nx run apex-ast-serializer:build:native
         env:

--- a/.github/workflows/update-jorje.yml
+++ b/.github/workflows/update-jorje.yml
@@ -14,6 +14,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      # Opening the PR needs PERSONAL_TOKEN. It's absent on contributor forks,
+      # so resolve it: fail on the canonical repo, skip (with a warning) on a
+      # fork, where this maintenance workflow has nothing useful to do anyway.
+      - name: Resolve personal token
+        id: pr_secret
+        uses: ./.github/actions/resolve-secret
+        with:
+          name: PERSONAL_TOKEN
+          value: ${{ secrets.PERSONAL_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v5.6.0
         with:
@@ -23,6 +32,7 @@ jobs:
       - name: Run create-jorje-jar.sh
         run: ./packages/apex-ast-serializer/tools/create-jorje-jar.sh
       - name: Create Pull Request
+        if: steps.pr_secret.outputs.available == 'true'
         uses: peter-evans/create-pull-request@v8.1.1
         with:
           commit-message: Updated jorje


### PR DESCRIPTION
Contributors have reported that some workflow steps can't run on their forks: the steps depend on secrets configured in this repo (`CODECOV_TOKEN`, `NX_KEY`, `PERSONAL_TOKEN`), and forks don't inherit them, so the steps hard-fail on fork CI and fork PRs.

This adds a `resolve-secret` composite action that centralizes one policy and wires it into the three affected steps:

- Secret present -> the dependent step runs as before.
- Secret missing on a fork (a fork's own push/schedule/dispatch, or a PR opened from a fork) -> the step is skipped with a `::warning::` annotation, so contributor CI stays green.
- Secret missing on the canonical repo (no upstream) -> the run fails loudly, so a dropped or renamed secret gets noticed instead of silently skipped.

Fork detection is two-pronged, on purpose:

- For a PR opened from a fork, the run executes in the base repo's context (`github.repository` is canonical, `fork` is false) but GitHub withholds secrets. So we also compare the PR's head repo to the base repo to recognize that case.
- For a fork's own runs, we query fork status via `gh api repos/<repo> --jq .fork` at runtime rather than reading `github.event.repository.fork`, which isn't populated on `schedule` events (and two of the three secrets fire on schedule).

Per-secret notes:

- `CODECOV_TOKEN` (`tests-deployments.yml`): both Codecov upload steps gate on one resolve.
- `NX_KEY` (`tests-deployments.yml`, native build): on a fork this falls back to a cloud-less build (`NX_NO_CLOUD=true`) rather than skipping the build, since the key only enables Nx Cloud caching. On the canonical repo a missing `NX_KEY` still fails, per the shared policy (this was a deliberate choice - it's non-fatal to the build itself, but failing keeps a dropped key visible).
- `PERSONAL_TOKEN` (`update-jorje.yml`): the create-PR step is skipped on forks, where this maintenance workflow has nothing useful to do anyway.

Nothing here touches formatted output, so no changelog entry. Canonical-repo behavior is unchanged when the secrets are present (the fast path never even calls the API).

Testing: YAML validated locally and the embedded shell logic passes shellcheck. The real end-to-end check is the GitHub Actions parser plus a manual dispatch - I'd suggest dispatching `tests-deployments.yml` on this branch to confirm the canonical path is unaffected, and eyeballing a fork run to confirm the skip path.

- [ ] I've added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I've added my changes to the `CHANGELOG.md` file in the `Unreleased` section. <!-- N/A: CI-only, no output change -->
- [x] I've read the contributing guidelines.