### PR TITLE
Pin prettier through a pnpm catalog instead of a $ override

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/semver": "7.8.0",
     "del-cli": "7.0.0",
     "nx": "23.2.0",
-    "prettier": "3.9.6",
+    "prettier": "catalog:",
     "prettier-plugin-java": "2.10.3",
     "prettier-plugin-organize-imports": "4.3.0",
     "semver": "7.8.5",

--- a/packages/prettier-plugin-apex/package.json
+++ b/packages/prettier-plugin-apex/package.json
@@ -56,6 +56,7 @@
     "@inquirer/prompts": "^8.5.2",
     "@types/wait-on": "5.3.4",
     "@vitest/coverage-v8": "5.0.0",
+    "prettier": "catalog:",
     "vite": "8.2.2",
     "vitest": "5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  prettier: 3.9.6
+catalogs:
+  default:
+    prettier:
+      specifier: 3.9.6
+      version: 3.9.6
 
 importers:
 
@@ -134,7 +137,7 @@ importers:
         specifier: 23.2.0
         version: 23.2.0
       prettier:
-        specifier: 3.9.6
+        specifier: 'catalog:'
         version: 3.9.6
       prettier-plugin-java:
         specifier: 2.10.3
@@ -211,9 +214,6 @@ importers:
       jest-docblock:
         specifier: ^30.0.0
         version: 30.5.0
-      prettier:
-        specifier: 3.9.6
-        version: 3.9.6
       wait-on:
         specifier: ^9.0.0
         version: 9.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
@@ -227,6 +227,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 5.0.0
         version: 5.0.0(vitest@5.0.0)
+      prettier:
+        specifier: 'catalog:'
+        version: 3.9.6
       vite:
         specifier: 8.2.2
         version: 8.2.2(@types/node@22.19.19)(esbuild@0.28.2)(tsx@4.23.13)(yaml@2.9.0)
@@ -1838,12 +1841,12 @@ packages:
   prettier-plugin-java@2.10.3:
     resolution: {integrity: sha512-/g52mTbsN2ee8JjLRpBWGGmcmRhdv2zRWyj4QbsL9CQ+nKR022GRJhebwEpRyaCc8hLV6aO3JPGNQyXp1DPrCA==}
     peerDependencies:
-      prettier: 3.9.6
+      prettier: ^3.0.0
 
   prettier-plugin-organize-imports@4.3.0:
     resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
     peerDependencies:
-      prettier: 3.9.6
+      prettier: '>=2.0'
       typescript: '>=2.9'
       vue-tsc: ^2.1.0 || 3
     peerDependenciesMeta:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,10 +7,11 @@ allowBuilds:
   esbuild: true
   nx: true
 
-# Force every prettier in the graph - including the plugin's `prettier` peer -
-# to the exact version pinned in the root devDependencies. Without this the peer
-# resolves independently and can lag the devDep, so a Renovate prettier bump
-# would not actually be exercised by the test suite (see the 3.9.0
-# comment.placement regression, which merged green for exactly this reason).
-overrides:
-  prettier: "$prettier"
+# Single source of truth for the prettier version. Every workspace package that
+# needs prettier depends on `catalog:`, including the plugin itself - its
+# `prettier` peer would otherwise resolve independently and could lag the
+# version we test against, so a Renovate prettier bump would not actually be
+# exercised by the test suite (see the 3.9.0 comment.placement regression,
+# which merged green for exactly this reason).
+catalog:
+  prettier: 3.9.6


### PR DESCRIPTION
#2449 (a Renovate `@inquirer/prompts` lockfile bump) fails CI on every matrix job with:

```
ERR_PNPM_OUTDATED_LOCKFILE
  specifiers in the lockfile don't match specifiers in package.json:
* in importers["packages/prettier-plugin-apex"]:
  - prettier (lockfile: ^3.0.0, manifest: 3.9.6)
```

Nothing to do with inquirer. `packages/prettier-plugin-apex` declares prettier only as a peerDependency `^3.0.0`; with `autoInstallPeers` pnpm records that peer as a real importer entry, and `overrides: prettier: "$prettier"` rewrote its specifier to the root's pinned `3.9.6`. Renovate's lockfile regeneration wrote the raw `^3.0.0` instead. Its lockfile still carried `overrides: prettier: 3.9.6` at the top, so overrides were loaded - only the auto-installed peer's specifier came out untransformed. I couldn't reproduce that exact behaviour locally with pnpm 12.3.2, so I can't name the Renovate-side trigger.

Separately, pnpm now warns on every install: `The "$" version reference syntax in overrides is deprecated (used by: prettier). Define the version in a catalog and reference it with the "catalog:" protocol instead.`

Rather than chase the Renovate flag, this removes the rewrite step entirely:

- `pnpm-workspace.yaml` gets a `catalog: { prettier: 3.9.6 }` and drops `overrides`.
- Root and plugin both depend on `prettier: "catalog:"`.
- The plugin now declares prettier as an explicit devDependency, so it's no longer an auto-installed peer. `peerDependencies: prettier: ^3.0.0` is unchanged, so published metadata is the same.

The importer specifier is now the literal string `catalog:`, copied verbatim from package.json - there's no transformation left for a lockfile regeneration to skip.

This keeps the intent of 0a1b1736 (the plugin's prettier peer must not lag the version we test against, per the 3.9.0 `comment.placement` regression that merged green): verified the lockfile resolves exactly one prettier, 3.9.6, everywhere. Renovate bumps the catalog entry the way it bumped the root devDependency.

Checks run locally: `prettier-plugin-apex:lint` passes, and the built-in-parser suite is 107/107 green. No changelog entry - no effect on formatted output.

Follow-up: #2449 needs a rebase on top of this before it can go green.