### PR TITLE
Pin pnpm/action-setup back to v6.0.10

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -96,7 +96,7 @@ jobs:
           ref: ${{ steps.setup.outputs.head_ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.1.0
+        uses: pnpm/action-setup@v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0

--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -175,7 +175,19 @@ jobs:
   build-native-executables:
     name: Build Native Executables
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags') || needs.changes.outputs.musl-script == 'true'
+    # Renovate branches build natively too. A dependency or action bump can
+    # break the toolchain in a way nothing else here would catch: the rest of
+    # PR CI is ubuntu-only, so anything Windows- or macOS-specific sails
+    # through green and only surfaces on the nightly, after automerge.
+    # Matching on ref_name catches the push event on the renovate branch,
+    # which is what branch automerge waits for; those checks show up on the
+    # PR too for the bumps that open one.
+    if: >-
+      github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
+      || startsWith(github.ref, 'refs/tags')
+      || needs.changes.outputs.musl-script == 'true'
+      || startsWith(github.ref_name, 'renovate/')
     strategy:
       matrix:
         os:
@@ -279,7 +291,11 @@ jobs:
           key: ${{ steps.nx-cache-restore.outputs.cache-primary-key }}
       - name: Rename executable
         run: mv parser/build/native/nativeCompile/${{ env.ASSET_NAME }} parser/build/native/nativeCompile/${{ env.OUTPUT_NAME }}
+      # Renovate branches build to prove the toolchain still works, not to
+      # produce anything. Without this they'd each upload four ~100MB binaries
+      # on every push, and Renovate rebases its branches whenever main moves.
       - name: Upload artifact
+        if: ${{ !startsWith(github.ref_name, 'renovate/') }}
         uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ env.OUTPUT_NAME }}

--- a/.github/workflows/tests-deployments.yml
+++ b/.github/workflows/tests-deployments.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.1.0
+        uses: pnpm/action-setup@v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0
@@ -146,10 +146,17 @@ jobs:
           - macos-latest
           - macos-15-intel
     runs-on: ${{ matrix.os }}
+    # Windows runners default to pwsh, where a broken toolchain can exit 0
+    # having done nothing: that's how the pnpm shim regression stayed green
+    # here for two nights. bash resolves pnpm through a shim that works, and
+    # with -e a command that genuinely fails takes the step down with it.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.1.0
+        uses: pnpm/action-setup@v6.0.10
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0
         with:
@@ -202,8 +209,11 @@ jobs:
       UPLOAD_ARTIFACTS: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags') }}
       OS: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # See the note on package-tests: bash so Windows resolves a working pnpm
+    # and a failing command actually fails the step.
     defaults:
       run:
+        shell: bash
         working-directory: ./packages/apex-ast-serializer
     steps:
       - uses: actions/checkout@v7
@@ -217,7 +227,7 @@ jobs:
           name: NX_KEY
           value: ${{ secrets.NX_KEY }}
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.1.0
+        uses: pnpm/action-setup@v6.0.10
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0
         with:
@@ -258,7 +268,6 @@ jobs:
           NX_KEY: ${{ steps.nx_secret.outputs.available == 'true' && secrets.NX_KEY || '' }}
           NX_NO_CLOUD: ${{ steps.nx_secret.outputs.available == 'true' && 'false' || 'true' }}
       - name: Sanity check native executable
-        shell: bash
         run: |
           ./parser/build/native/nativeCompile/${{ env.ASSET_NAME }} -l ../prettier-plugin-apex/tests/loop/LoopClass.cls > "$RUNNER_TEMP/sanity-check.json"
           node -e "const fs=require('fs'); JSON.parse(fs.readFileSync(process.argv[1],'utf8')); console.log('Sanity check passed');" "$RUNNER_TEMP/sanity-check.json"
@@ -293,7 +302,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.1.0
+        uses: pnpm/action-setup@v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0

--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,19 @@
       "allowedVersions": "!/^5\\.0\\.3$/"
     },
     {
+      // v6.1.0 switched the pnpm 12 bootstrap from @pnpm/exe to the plain npm
+      // package, whose .ps1 shim invokes an extensionless native binary that
+      // PowerShell silently ignores. Every pnpm step on Windows exited 0
+      // having done nothing, so the Windows jobs went false-green and the
+      // native build only failed later, on its missing executable.
+      // This blocks that one release; a later one carrying the same bug gets
+      // caught by the native build that now runs on Renovate branches.
+      // The v? matters: the github-tags datasource reports tags, so versions
+      // arrive as "v6.1.0", not "6.1.0".
+      "matchPackageNames": ["pnpm/action-setup"],
+      "allowedVersions": "!/^v?6\\.1\\.0$/"
+    },
+    {
       "matchPackageNames": ["@types/node"],
       "enabled": false
     },


### PR DESCRIPTION
The nightly `Build Native Executables (windows-latest)` job has failed since Sep 9 ([example](https://github.com/dangmai/prettier-plugin-apex/actions/runs/34478484856)). It isn't the GraalVM `native-build-tools` 1.1.12 bump: the Sep 8 nightly ran at `5655a5cc`, which already contained that bump, and it was green. The first bad sha is `658d7ca3`, the `pnpm/action-setup` v6.0.10 -> v6.1.0 bump.

## What actually happens

[v6.1.0](https://github.com/pnpm/action-setup/compare/v6.0.10...v6.1.0) switched the pnpm 12 bootstrap from `@pnpm/exe` to the plain `pnpm` npm package. That package ships **native binaries** as its `bin` entries, so `node_modules/pnpm/` ends up with both `pnpm` and `pnpm.exe`. npm then generates its usual shims in `node_modules/.bin`, and the PowerShell one is wrong for a native-binary bin:

```powershell
$exe=""
if (... -or $IsWindows) { $exe=".exe" }   # computed, then never used
& "$basedir/../pnpm/pnpm"   $args          # extensionless
exit $LASTEXITCODE
```

That's npm's template for a Node-script bin. Pointed at an extensionless native binary, PowerShell's `&` does nothing at all: no output, `$LASTEXITCODE` never set, so `exit $LASTEXITCODE` exits 0.

`node_modules/.bin` is what the action puts on PATH as `PNPM_HOME` for the pnpm 12 path (the Windows workaround that points PATH at the real binary directory is still gated on `standalone` only). And since the pinned bootstrap version is exactly 12.3.4, matching our `packageManager`, the new early return skips `self-update` — so the action never runs pnpm itself and never populates `$PNPM_HOME/bin` with a working binary.

GitHub's default shell on Windows runners is `pwsh -command ". '{0}'"`, so every `pnpm ...` step silently no-ops and reports success. Confirmed on a throwaway branch, same job, same PATH:

| shell | result |
| --- | --- |
| pwsh (the default) | no output, `LASTEXITCODE=0` |
| bash | `12.3.4`, `exit=0`, resolves to `.bin/pnpm`, the `sh` shim, which `exec`s the binary fine |

In the logs that looks like `pnpm install --frozen-lockfile` dropping from 6s (`Done in 5.8s using pnpm v12.3.4`) to 0.5s with zero output, and `pnpm nx run apex-ast-serializer:build:native` dropping from 7.5 minutes to 0.9s. Nothing is installed, nothing is built, and the job only fails at the sanity check because that's the first step that looks for the native binary.

Upstream tests this exact matrix cell (`windows / v12.3.4`), but every assertion step in their workflow is `shell: bash`, where the `sh` shim works. Nothing exercises the PowerShell path, which is what every default `run:` step on a Windows runner uses. That's why there's no issue filed for it.

## Why CI didn't catch it before the merge

`Test latest Prettier Apex package (windows-latest)` was hit identically and reported success anyway — both of its steps were silent no-ops, because the default pwsh shell neither stops on a failing command nor propagates its exit code. We had a false green there for two nights.

Worse, none of it was visible on the Renovate PR. `package-tests` and `build-native-executables` only run on `schedule`/`workflow_dispatch`/tags, and `functional-tests` is `runs-on: ubuntu-latest`, so a bump of the action had no Windows check to fail anywhere. It automerged green.

## Changes

- Pin `pnpm/action-setup` back to v6.0.10 everywhere, and add a Renovate rule holding it off v6.1.0 until upstream fixes the Windows shim. v6.0.10 uses the `@pnpm/exe` path, which puts a real `pnpm.exe` directory on PATH.
- Default the two Windows-inclusive matrix jobs (`package-tests`, `build-native-executables`) to `shell: bash`, so a broken toolchain can't pass quietly. Per the table above bash also sidesteps the broken shim outright, so the two fixes overlap. That makes the explicit `shell: bash` on the sanity check redundant, so it's gone.
- Build native executables on Renovate branches, so any bump that breaks the toolchain on any platform fails before it merges rather than on the following nightly.

On that last one: most bumps here automerge via `automergeType: "branch"` and never open a PR, so the gate matches on `github.ref_name` to catch the push event on the branch, which is what branch automerge waits for. Those checks also show on the PR for the bumps that do open one. Verified by pushing a `renovate/`-prefixed branch and confirming all four native jobs get created rather than skipped.

Two consequences worth knowing: every bump now costs ~10 minutes of native build (free on a public repo, but it delays automerge), and a flaky build blocks automerge until someone reruns it. We hit exactly that during this work — a transient Gradle Plugin Portal miss on an artifact that resolves fine. If it gets annoying, a Gradle retry or a Maven Central fallback repo would be a separate change.

## Verification

[Workflow dispatch on this branch](https://github.com/dangmai/prettier-plugin-apex/actions/runs/34533480560) is fully green, and the Windows jobs are doing real work again rather than passing quietly: install 5-6s, package tests 39s, native build 7m23s, sanity check passes.

- [ ] I’ve added tests to confirm my change works. (n/a, CI-only)
- [ ] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section. (n/a, no output change)
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/main/CONTRIBUTING.md).
